### PR TITLE
feat: wire --help parser as fallback spec provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,7 @@ dependencies = [
  "dirs",
  "interprocess",
  "nighthawk-proto",
+ "parking_lot",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/nighthawk-daemon/Cargo.toml
+++ b/crates/nighthawk-daemon/Cargo.toml
@@ -21,6 +21,7 @@ dirs.workspace = true
 toml.workspace = true
 thiserror.workspace = true
 async-trait.workspace = true
+parking_lot = "0.12"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/nighthawk-daemon/src/main.rs
+++ b/crates/nighthawk-daemon/src/main.rs
@@ -51,7 +51,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let fig_provider = specs::fig::FigSpecProvider::new(specs_dir.clone());
         let help_cache_dir = specs_dir.join("help_cache");
-        let help_provider = specs::helpparse::HelpParseProvider::new(help_cache_dir);
+        if let Err(e) = std::fs::create_dir_all(&help_cache_dir) {
+            tracing::warn!("Failed to create help cache dir: {e}");
+        }
+        let help_provider = specs::helpparse::HelpParseProvider::new(
+            help_cache_dir,
+            tokio::runtime::Handle::current(),
+        );
 
         let registry = Arc::new(specs::SpecRegistry::new(vec![
             Box::new(fig_provider),

--- a/crates/nighthawk-daemon/src/specs/helpparse.rs
+++ b/crates/nighthawk-daemon/src/specs/helpparse.rs
@@ -1,23 +1,277 @@
 use super::{CliSpec, OptionSpec, SpecProvider, SubcommandSpec};
-use std::collections::HashMap;
-use std::path::PathBuf;
+use parking_lot::RwLock;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+
+/// Maximum bytes to read from --help output before truncating.
+const MAX_HELP_OUTPUT_BYTES: usize = 256 * 1024;
+
+/// Timeout for running `command --help`.
+const HELP_TIMEOUT_SECS: u64 = 5;
 
 /// Parses --help output from CLIs to generate completion specs on the fly.
 ///
 /// When a command isn't in the fig specs, we run `command --help`, parse
-/// the output, and cache the result to disk for future use.
-///
-/// TODO: Implement parsers for common --help formats (GNU, clap, cobra, argparse).
+/// the output, and cache the result to disk for future use. The first
+/// request for an unknown command returns None (triggering a background
+/// parse); subsequent requests return the cached result.
 pub struct HelpParseProvider {
-    _cache_dir: PathBuf,
-    cache: HashMap<String, CliSpec>,
+    cache_dir: PathBuf,
+    cache: Arc<RwLock<HashMap<String, CliSpec>>>,
+    pending: Arc<RwLock<HashSet<String>>>,
+    failed: Arc<RwLock<HashSet<String>>>,
+    runtime_handle: tokio::runtime::Handle,
 }
 
 impl HelpParseProvider {
-    pub fn new(cache_dir: PathBuf) -> Self {
+    pub fn new(cache_dir: PathBuf, runtime_handle: tokio::runtime::Handle) -> Self {
+        let cache = Self::load_disk_cache(&cache_dir);
+        tracing::info!(
+            count = cache.len(),
+            "Loaded --help cache entries from {}",
+            cache_dir.display()
+        );
         Self {
-            _cache_dir: cache_dir,
-            cache: HashMap::new(),
+            cache_dir,
+            cache: Arc::new(RwLock::new(cache)),
+            pending: Arc::new(RwLock::new(HashSet::new())),
+            failed: Arc::new(RwLock::new(HashSet::new())),
+            runtime_handle,
+        }
+    }
+
+    fn load_disk_cache(cache_dir: &Path) -> HashMap<String, CliSpec> {
+        let mut cache = HashMap::new();
+        let entries = match std::fs::read_dir(cache_dir) {
+            Ok(entries) => entries,
+            Err(_) => return cache,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            // Clean up stale .tmp files from interrupted writes
+            if path.extension().and_then(|e| e.to_str()) == Some("tmp") {
+                let _ = std::fs::remove_file(&path);
+                continue;
+            }
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let command = match path.file_stem().and_then(|s| s.to_str()) {
+                Some(name) => name.to_string(),
+                None => continue,
+            };
+            match std::fs::read_to_string(&path) {
+                Ok(contents) => match serde_json::from_str::<CliSpec>(&contents) {
+                    Ok(spec) => {
+                        cache.insert(command, spec);
+                    }
+                    Err(e) => {
+                        tracing::warn!(path = %path.display(), error = %e, "Bad help cache file");
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(path = %path.display(), error = %e, "Failed to read help cache");
+                }
+            }
+        }
+        cache
+    }
+
+    fn spawn_help_parse(&self, command: &str) {
+        let command = command.to_string();
+
+        // Mark as pending to prevent duplicate spawns
+        {
+            let mut pending = self.pending.write();
+            if !pending.insert(command.clone()) {
+                return;
+            }
+        }
+
+        let cache = Arc::clone(&self.cache);
+        let pending = Arc::clone(&self.pending);
+        let failed = Arc::clone(&self.failed);
+        let cache_dir = self.cache_dir.clone();
+
+        self.runtime_handle.spawn(async move {
+            let result = Self::run_help_parse(&command).await;
+
+            // Remove from pending
+            pending.write().remove(&command);
+
+            match result {
+                Some(spec) => {
+                    Self::write_disk_cache(&cache_dir, &command, &spec);
+                    cache.write().insert(command, spec);
+                }
+                None => {
+                    // Negative cache: don't retry this command
+                    failed.write().insert(command);
+                }
+            }
+        });
+    }
+
+    async fn run_help_parse(command: &str) -> Option<CliSpec> {
+        if !Self::is_safe_command_name(command) {
+            tracing::debug!(command, "Rejected unsafe command name");
+            return None;
+        }
+
+        if !Self::command_exists_in_path(command).await {
+            tracing::debug!(command, "Command not found in PATH");
+            return None;
+        }
+
+        // Try --help first, then -h as fallback
+        if let Some(spec) = Self::try_help_flag(command, "--help").await {
+            return Some(spec);
+        }
+        Self::try_help_flag(command, "-h").await
+    }
+
+    async fn try_help_flag(command: &str, flag: &str) -> Option<CliSpec> {
+        let output = match tokio::time::timeout(
+            std::time::Duration::from_secs(HELP_TIMEOUT_SECS),
+            tokio::process::Command::new(command)
+                .arg(flag)
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .kill_on_drop(true)
+                .output(),
+        )
+        .await
+        {
+            Ok(Ok(output)) => output,
+            Ok(Err(e)) => {
+                tracing::debug!(command, flag, error = %e, "Failed to run help command");
+                return None;
+            }
+            Err(_) => {
+                tracing::debug!(command, flag, "Help command timed out");
+                return None;
+            }
+        };
+
+        // Use stdout; some commands write help to stderr
+        let raw = if !output.stdout.is_empty() {
+            &output.stdout
+        } else {
+            &output.stderr
+        };
+
+        if raw.is_empty() {
+            return None;
+        }
+
+        // Cap output size to prevent memory bloat
+        let truncated = &raw[..raw.len().min(MAX_HELP_OUTPUT_BYTES)];
+        let text = String::from_utf8_lossy(truncated);
+
+        let spec = Self::parse_help_text(command, &text);
+
+        // Reject garbage: must have at least one option or subcommand
+        if spec.options.is_empty() && spec.subcommands.is_empty() {
+            tracing::debug!(
+                command,
+                flag,
+                "Parsed help but found no options/subcommands"
+            );
+            return None;
+        }
+
+        tracing::info!(
+            command,
+            flag,
+            options = spec.options.len(),
+            subcommands = spec.subcommands.len(),
+            "Parsed help output"
+        );
+        Some(spec)
+    }
+
+    fn is_safe_command_name(command: &str) -> bool {
+        if command.is_empty() || command.len() > 255 {
+            return false;
+        }
+        if command.contains('/') || command.contains('\\') {
+            return false;
+        }
+        !command.chars().any(|c| {
+            matches!(
+                c,
+                '\0' | ';'
+                    | '&'
+                    | '|'
+                    | '$'
+                    | '`'
+                    | '('
+                    | ')'
+                    | '{'
+                    | '}'
+                    | '<'
+                    | '>'
+                    | '!'
+                    | '\n'
+                    | '\r'
+                    | ' '
+                    | '\t'
+                    | '"'
+                    | '\''
+            )
+        })
+    }
+
+    async fn command_exists_in_path(command: &str) -> bool {
+        #[cfg(unix)]
+        let check = tokio::process::Command::new("which")
+            .arg(command)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await;
+
+        #[cfg(windows)]
+        let check = tokio::process::Command::new("where")
+            .arg(command)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await;
+
+        matches!(check, Ok(status) if status.success())
+    }
+
+    fn write_disk_cache(cache_dir: &Path, command: &str, spec: &CliSpec) {
+        if let Err(e) = std::fs::create_dir_all(cache_dir) {
+            tracing::warn!(error = %e, "Failed to create help cache dir");
+            return;
+        }
+        let final_path = cache_dir.join(format!("{command}.json"));
+        let tmp_path = cache_dir.join(format!("{command}.json.tmp"));
+
+        let json = match serde_json::to_string_pretty(spec) {
+            Ok(json) => json,
+            Err(e) => {
+                tracing::warn!(command, error = %e, "Failed to serialize spec");
+                return;
+            }
+        };
+
+        // Atomic write: write to .tmp then rename
+        if let Err(e) = std::fs::write(&tmp_path, &json) {
+            tracing::warn!(path = %tmp_path.display(), error = %e, "Failed to write temp cache file");
+            return;
+        }
+        if let Err(e) = std::fs::rename(&tmp_path, &final_path) {
+            tracing::warn!(error = %e, "Failed to rename temp cache file");
+            // Clean up temp file
+            let _ = std::fs::remove_file(&tmp_path);
         }
     }
 
@@ -126,13 +380,32 @@ impl HelpParseProvider {
 
 impl SpecProvider for HelpParseProvider {
     fn get_spec(&self, command: &str) -> Option<CliSpec> {
-        self.cache.get(command).cloned()
-        // TODO: On cache miss, run `command --help`, parse output,
-        // cache to self.cache and to disk at self.cache_dir
+        // Check in-memory cache
+        if let Some(spec) = self.cache.read().get(command) {
+            return Some(spec.clone());
+        }
+
+        // Don't retry known failures
+        if self.failed.read().contains(command) {
+            return None;
+        }
+
+        // Don't double-spawn
+        if self.pending.read().contains(command) {
+            return None;
+        }
+
+        // Spawn background task to run --help
+        self.spawn_help_parse(command);
+        None
     }
 
     fn known_commands(&self) -> Vec<String> {
-        self.cache.keys().cloned().collect()
+        self.cache.read().keys().cloned().collect()
+    }
+
+    fn is_fallback(&self) -> bool {
+        true
     }
 }
 
@@ -180,5 +453,107 @@ Commands:
         // Should find subcommands
         assert!(spec.subcommands.iter().any(|s| s.name == "init"));
         assert!(spec.subcommands.iter().any(|s| s.name == "build"));
+    }
+
+    #[test]
+    fn reject_empty_parse_result() {
+        let spec = HelpParseProvider::parse_help_text(
+            "bad",
+            "This is not help output.\nJust random text with no flags.",
+        );
+        assert!(spec.options.is_empty());
+        assert!(spec.subcommands.is_empty());
+    }
+
+    #[test]
+    fn disk_cache_round_trip() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let spec = HelpParseProvider::parse_help_text(
+            "myapp",
+            "  -f, --force  Force\n  init  Initialize\n",
+        );
+
+        HelpParseProvider::write_disk_cache(dir.path(), "myapp", &spec);
+
+        // Verify .tmp file is cleaned up
+        assert!(!dir.path().join("myapp.json.tmp").exists());
+        assert!(dir.path().join("myapp.json").exists());
+
+        let cache = HelpParseProvider::load_disk_cache(dir.path());
+        assert!(cache.contains_key("myapp"));
+        let loaded = &cache["myapp"];
+        assert_eq!(loaded.name, "myapp");
+        assert!(!loaded.options.is_empty());
+        assert!(!loaded.subcommands.is_empty());
+    }
+
+    #[test]
+    fn corrupt_cache_file_skipped() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("bad.json"), "not valid json{{{").unwrap();
+        std::fs::write(
+            dir.path().join("good.json"),
+            r#"{"name":"good","subcommands":[],"options":[],"args":[]}"#,
+        )
+        .unwrap();
+
+        let cache = HelpParseProvider::load_disk_cache(dir.path());
+        assert!(!cache.contains_key("bad"));
+        assert!(cache.contains_key("good"));
+    }
+
+    #[test]
+    fn tmp_files_cleaned_up_by_cache_loader() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let tmp_path = dir.path().join("leftover.json.tmp");
+        std::fs::write(
+            &tmp_path,
+            r#"{"name":"leftover","subcommands":[],"options":[],"args":[]}"#,
+        )
+        .unwrap();
+
+        let cache = HelpParseProvider::load_disk_cache(dir.path());
+        assert!(cache.is_empty());
+        // Stale .tmp file should be cleaned up
+        assert!(!tmp_path.exists());
+    }
+
+    #[test]
+    fn command_validation_rejects_metacharacters() {
+        assert!(!HelpParseProvider::is_safe_command_name(""));
+        assert!(!HelpParseProvider::is_safe_command_name("cmd;rm"));
+        assert!(!HelpParseProvider::is_safe_command_name("cmd|pipe"));
+        assert!(!HelpParseProvider::is_safe_command_name("cmd&bg"));
+        assert!(!HelpParseProvider::is_safe_command_name("/usr/bin/ls"));
+        assert!(!HelpParseProvider::is_safe_command_name("cmd with spaces"));
+        assert!(!HelpParseProvider::is_safe_command_name("$(evil)"));
+        assert!(!HelpParseProvider::is_safe_command_name("cmd\ninjection"));
+        assert!(!HelpParseProvider::is_safe_command_name("cmd\0null"));
+
+        assert!(HelpParseProvider::is_safe_command_name("ls"));
+        assert!(HelpParseProvider::is_safe_command_name("git"));
+        assert!(HelpParseProvider::is_safe_command_name("cargo-clippy"));
+        assert!(HelpParseProvider::is_safe_command_name("python3.11"));
+    }
+
+    #[test]
+    fn negative_cache_prevents_retry() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let handle = rt.handle().clone();
+
+        let provider = HelpParseProvider::new(dir.path().to_path_buf(), handle);
+
+        // Simulate a failed command by inserting into failed set
+        provider.failed.write().insert("badcmd".to_string());
+
+        // get_spec should return None without spawning
+        assert!(provider.get_spec("badcmd").is_none());
+
+        // Verify it's not in pending (no spawn happened)
+        assert!(!provider.pending.read().contains("badcmd"));
     }
 }

--- a/crates/nighthawk-daemon/src/specs/mod.rs
+++ b/crates/nighthawk-daemon/src/specs/mod.rs
@@ -1,14 +1,14 @@
 pub mod fig;
 pub mod helpparse;
 
-use serde::Deserialize;
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::RwLock;
 
 // --- Spec data structures ---
 
 /// A parsed CLI completion spec.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CliSpec {
     pub name: String,
     #[serde(default)]
@@ -21,7 +21,7 @@ pub struct CliSpec {
     pub args: Vec<ArgSpec>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SubcommandSpec {
     pub name: String,
     #[serde(default)]
@@ -36,7 +36,7 @@ pub struct SubcommandSpec {
     pub args: Vec<ArgSpec>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OptionSpec {
     pub names: Vec<String>,
     #[serde(default)]
@@ -47,7 +47,7 @@ pub struct OptionSpec {
     pub is_required: bool,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ArgSpec {
     #[serde(default)]
     pub name: Option<String>,
@@ -61,7 +61,7 @@ pub struct ArgSpec {
     pub template: Option<ArgTemplate>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ArgTemplate {
     Filepaths,
@@ -77,12 +77,19 @@ pub trait SpecProvider: Send + Sync {
 
     /// List all known command names.
     fn known_commands(&self) -> Vec<String>;
+
+    /// If true, SpecRegistry will NOT cache None results from this provider.
+    /// Used by providers that populate asynchronously (e.g., --help parser).
+    fn is_fallback(&self) -> bool {
+        false
+    }
 }
 
 // --- SpecRegistry ---
 
 /// Chains multiple SpecProviders with an in-memory cache.
 /// Providers are queried in order; first match wins and gets cached.
+/// Fallback providers (is_fallback() == true) should be registered last.
 pub struct SpecRegistry {
     providers: Vec<Box<dyn SpecProvider>>,
     cache: RwLock<HashMap<String, Option<CliSpec>>>,
@@ -97,26 +104,34 @@ impl SpecRegistry {
     }
 
     /// Look up a spec by command name. Cached after first lookup.
+    ///
+    /// When all providers return None and the last queried provider is a
+    /// fallback (may populate asynchronously), the None is NOT cached so
+    /// the next request can retry.
     pub fn lookup(&self, command: &str) -> Option<CliSpec> {
         // Check cache first
-        if let Ok(cache) = self.cache.read() {
-            if let Some(cached) = cache.get(command) {
-                return cached.clone();
-            }
+        if let Some(cached) = self.cache.read().get(command) {
+            return cached.clone();
         }
 
         // Query providers in order
         let mut result = None;
+        let mut last_was_fallback = false;
         for provider in &self.providers {
             if let Some(spec) = provider.get_spec(command) {
                 result = Some(spec);
+                last_was_fallback = false;
                 break;
             }
+            last_was_fallback = provider.is_fallback();
         }
 
-        // Cache the result (even None, to avoid repeated lookups)
-        if let Ok(mut cache) = self.cache.write() {
-            cache.insert(command.to_string(), result.clone());
+        // Cache the result — but NOT if it's None and the last queried
+        // provider is a fallback (it may populate asynchronously)
+        if result.is_some() || !last_was_fallback {
+            self.cache
+                .write()
+                .insert(command.to_string(), result.clone());
         }
 
         result
@@ -173,5 +188,161 @@ mod tests {
 
         // Unknown command returns None
         assert!(registry.lookup("unknown").is_none());
+    }
+
+    #[test]
+    fn registry_retries_when_fallback_returns_none() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        struct Inner {
+            ready: AtomicBool,
+        }
+        struct DelayedFallback {
+            inner: Arc<Inner>,
+        }
+
+        impl SpecProvider for DelayedFallback {
+            fn get_spec(&self, command: &str) -> Option<CliSpec> {
+                if self.inner.ready.load(Ordering::SeqCst) {
+                    Some(CliSpec {
+                        name: command.into(),
+                        description: None,
+                        subcommands: vec![],
+                        options: vec![],
+                        args: vec![],
+                    })
+                } else {
+                    None
+                }
+            }
+            fn known_commands(&self) -> Vec<String> {
+                vec![]
+            }
+            fn is_fallback(&self) -> bool {
+                true
+            }
+        }
+
+        let inner = Arc::new(Inner {
+            ready: AtomicBool::new(false),
+        });
+        let provider = DelayedFallback {
+            inner: Arc::clone(&inner),
+        };
+        let registry = SpecRegistry::new(vec![Box::new(provider)]);
+
+        // First lookup: fallback returns None, NOT cached
+        assert!(registry.lookup("mycmd").is_none());
+
+        // Simulate background task completing
+        inner.ready.store(true, Ordering::SeqCst);
+
+        // Second lookup: provider queried again (not cached), returns Some
+        assert!(registry.lookup("mycmd").is_some());
+    }
+
+    #[test]
+    fn registry_caches_none_from_non_fallback() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        struct Inner {
+            call_count: AtomicUsize,
+        }
+        struct CountingProvider {
+            inner: Arc<Inner>,
+        }
+
+        impl SpecProvider for CountingProvider {
+            fn get_spec(&self, _command: &str) -> Option<CliSpec> {
+                self.inner.call_count.fetch_add(1, Ordering::SeqCst);
+                None
+            }
+            fn known_commands(&self) -> Vec<String> {
+                vec![]
+            }
+            // is_fallback() defaults to false
+        }
+
+        let inner = Arc::new(Inner {
+            call_count: AtomicUsize::new(0),
+        });
+        let provider = CountingProvider {
+            inner: Arc::clone(&inner),
+        };
+        let registry = SpecRegistry::new(vec![Box::new(provider)]);
+
+        // First lookup queries the provider
+        assert!(registry.lookup("unknown").is_none());
+        assert_eq!(inner.call_count.load(Ordering::SeqCst), 1);
+
+        // Second lookup hits cache, does NOT query provider again
+        assert!(registry.lookup("unknown").is_none());
+        assert_eq!(inner.call_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn two_providers_normal_miss_fallback_miss_not_cached() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        // Simulates real provider chain: FigSpecProvider (normal) + HelpParseProvider (fallback)
+        struct NormalProvider;
+        impl SpecProvider for NormalProvider {
+            fn get_spec(&self, _command: &str) -> Option<CliSpec> {
+                None
+            }
+            fn known_commands(&self) -> Vec<String> {
+                vec![]
+            }
+        }
+
+        struct Inner {
+            ready: AtomicBool,
+        }
+        struct DelayedFallback {
+            inner: Arc<Inner>,
+        }
+        impl SpecProvider for DelayedFallback {
+            fn get_spec(&self, command: &str) -> Option<CliSpec> {
+                if self.inner.ready.load(Ordering::SeqCst) {
+                    Some(CliSpec {
+                        name: command.into(),
+                        description: None,
+                        subcommands: vec![],
+                        options: vec![],
+                        args: vec![],
+                    })
+                } else {
+                    None
+                }
+            }
+            fn known_commands(&self) -> Vec<String> {
+                vec![]
+            }
+            fn is_fallback(&self) -> bool {
+                true
+            }
+        }
+
+        let inner = Arc::new(Inner {
+            ready: AtomicBool::new(false),
+        });
+        let registry = SpecRegistry::new(vec![
+            Box::new(NormalProvider),
+            Box::new(DelayedFallback {
+                inner: Arc::clone(&inner),
+            }),
+        ]);
+
+        // Both miss → None NOT cached (fallback is last queried)
+        assert!(registry.lookup("rg").is_none());
+
+        // Fallback populates asynchronously
+        inner.ready.store(true, Ordering::SeqCst);
+
+        // Next lookup retries and finds the result
+        assert!(registry.lookup("rg").is_some());
     }
 }


### PR DESCRIPTION
## Summary

Closes #2

When a command has no pre-built fig spec (~689 commands), the daemon now automatically runs `command --help` in the background, parses the output into a `CliSpec`, and caches it to disk. This means nighthawk can provide completions for **any CLI tool** that supports `--help` or `-h`.

- **First request** for an unknown command returns empty (background parse spawned)
- **Subsequent requests** return cached completions (~15ms later, faster than a keystroke)
- **Disk cache** at `~/.config/nighthawk/specs/help_cache/` survives daemon restarts
- **Negative cache** prevents retrying commands where `--help` fails
- **Security hardened**: command name validation, PATH check, `stdin(null)`, 256KB output cap, 5s timeout, `kill_on_drop`

### Files changed

| File | Change |
|------|--------|
| `specs/mod.rs` | Add `Serialize` to spec types, `is_fallback()` trait method, skip caching None from fallback providers, switch to `parking_lot::RwLock` |
| `specs/helpparse.rs` | Major rewrite: background `--help` spawn, disk cache, negative cache, atomic writes, `-h` fallback |
| `main.rs` | Pass `Handle::current()` to HelpParseProvider, create cache dir |
| `Cargo.toml` | Add `parking_lot = "0.12"` |

### Test plan

- [x] `cargo build` — compiles
- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — 46 tests pass (38 unit + 5 integration + 3 proto)
- [x] 8 new unit tests: fallback retry, negative cache, disk round-trip, corrupt file handling, tmp cleanup, command validation, two-provider chain
- [x] Manual WSL test: `free`, `findmnt` (no fig spec) — empty first request, flags returned after ~15ms, cache persists across restart
- [x] Manual WSL test: `git` (fig spec) — still works, unaffected
- [x] Manual WSL test: nonsense command — empty, daemon stays alive

🤖 Generated with [Claude Code](https://claude.com/claude-code)