### PR TITLE
feat: add fuzzy display mode config (hint vs inline)

### DIFF
--- a/crates/nighthawk-cli/src/setup.rs
+++ b/crates/nighthawk-cli/src/setup.rs
@@ -61,11 +61,15 @@ fn find_specs_dir() -> Option<PathBuf> {
 }
 
 /// Copy a file, creating parent dirs as needed.
+/// Normalizes line endings to LF so shell plugins work on Linux/macOS
+/// even when copied from a Windows checkout.
 fn copy_file(src: &Path, dst: &Path) -> Result<(), Box<dyn std::error::Error>> {
     if let Some(parent) = dst.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    std::fs::copy(src, dst)?;
+    let content = std::fs::read_to_string(src)?;
+    let normalized = content.replace("\r\n", "\n");
+    std::fs::write(dst, normalized)?;
     Ok(())
 }
 

--- a/shells/nighthawk.zsh
+++ b/shells/nighthawk.zsh
@@ -6,6 +6,7 @@
 
 # --- Configuration ---
 NIGHTHAWK_SOCKET="${NIGHTHAWK_SOCKET:-/tmp/nighthawk-$(id -u).sock}"
+NIGHTHAWK_FUZZY_DISPLAY="${NIGHTHAWK_FUZZY_DISPLAY:-hint}"
 
 # --- State ---
 typeset -g _nh_suggestion=""
@@ -91,6 +92,18 @@ _nh_render_diff() {
         region_highlight+=("$hl")
     done
     _nh_has_highlight=${#diff_highlights[@]}
+}
+
+# --- Hint rendering for fuzzy matches ---
+# Shows " -> suggestion" as gray POSTDISPLAY text.
+# Does NOT modify BUFFER, so no save/restore dance needed.
+_nh_render_hint() {
+    local suggestion="$1"
+    if [[ -n "$suggestion" ]]; then
+        POSTDISPLAY=" → $suggestion"
+        region_highlight+=("${#BUFFER} $((${#BUFFER} + ${#POSTDISPLAY})) fg=8")
+        _nh_has_highlight=1
+    fi
 }
 
 # --- Restore original buffer before user edits ---
@@ -209,9 +222,13 @@ _nh_query() {
         _nh_replace_end="$replace_end"
 
         if [[ -n "$diff_ops_str" ]]; then
-            # Fuzzy match: render inline diff
-            _nh_diff_ops="$diff_ops_str"
-            _nh_render_diff "$diff_ops_str" "$replace_start" "$replace_end"
+            # Fuzzy match: render based on display mode
+            if [[ "$NIGHTHAWK_FUZZY_DISPLAY" == "hint" ]]; then
+                _nh_render_hint "$text"
+            else
+                _nh_diff_ops="$diff_ops_str"
+                _nh_render_diff "$diff_ops_str" "$replace_start" "$replace_end"
+            fi
         else
             # Prefix match: render ghost text suffix
             local already_typed_len=$(( cursor - replace_start ))


### PR DESCRIPTION
## Summary

- Add `NIGHTHAWK_FUZZY_DISPLAY` env var to zsh plugin (`hint` default, `inline` opt-in) — controls how fuzzy match suggestions render
- **Hint mode**: shows ` → correction` in gray POSTDISPLAY, no BUFFER mutation
- **Inline mode**: existing red/gray diff rendering in BUFFER
- Fix CRLF line endings in `nh setup` — normalize `\r\n` → `\n` when copying shell plugins

## Test plan

- [x] `cargo test` — all 111 tests pass
- [x] e2e fuzzy tests — 15/15 pass
- [x] e2e edge case tests — 16/16 pass
- [x] Manual: hint mode renders ` → checkout` for `git chekout`
- [x] Manual: `export NIGHTHAWK_FUZZY_DISPLAY=inline` switches to inline diff
- [x] Manual: Tab accepts suggestion in both modes
- [x] Manual: prefix matches unaffected by display mode
- [x] Manual: `nh setup zsh` copies plugin with LF endings (no ^M errors)

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)