### PR TITLE
feat: add PowerShell plugin with PSReadLine ghost text

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,8 +64,8 @@ Open-source, local-first, cross-platform terminal autocomplete with inline ghost
 - **PID file:** `~/.config/nighthawk/nighthawk.pid` — written by `nh start`, cleaned up on `nh stop` and daemon graceful shutdown.
 - **Log file:** `~/.config/nighthawk/daemon.log` — daemon stdout/stderr redirected here by `nh start`.
 - **Specs location:** `~/.config/nighthawk/specs/` (after `nh setup`) or `NIGHTHAWK_SPECS_DIR` env var override.
-- **Plugin location:** `~/.config/nighthawk/nighthawk.zsh` (after `nh setup`).
-- **Auto-start:** Zsh plugin checks if socket exists, tries `nh start` once if missing.
+- **Plugin location:** `~/.config/nighthawk/nighthawk.zsh` or `nighthawk.ps1` (after `nh setup`).
+- **Auto-start:** Shell plugins check if socket/pipe exists, try `nh start` once if missing.
 - **Binary discovery:** `nh start` finds `nighthawk-daemon` next to the `nh` binary, falls back to PATH.
 
 ## Key traits

--- a/crates/nighthawk-cli/src/setup.rs
+++ b/crates/nighthawk-cli/src/setup.rs
@@ -16,8 +16,12 @@ fn shell_info(shell: &str) -> Result<(&str, PathBuf), String> {
                 .join("nighthawk.fish"),
         )),
         "powershell" | "pwsh" => {
-            // PowerShell profile path varies; just print instructions
-            Err("PowerShell setup: add this to your $PROFILE:\n  . ~/.config/nighthawk/nighthawk.ps1".into())
+            let docs = dirs::document_dir().unwrap_or_else(|| home.join("Documents"));
+            Ok((
+                "nighthawk.ps1",
+                docs.join("PowerShell")
+                    .join("Microsoft.PowerShell_profile.ps1"),
+            ))
         }
         _ => Err(format!(
             "Unknown shell: {shell}\nSupported: zsh, bash, fish, powershell"
@@ -147,6 +151,11 @@ pub fn setup_shell(shell: &str) -> Result<(), Box<dyn std::error::Error>> {
         // Fish uses conf.d — just copying the file IS the setup
         println!("Fish plugin installed to {}", rc_path.display());
         return Ok(());
+    } else if shell == "powershell" || shell == "pwsh" {
+        format!(
+            "\n# nighthawk — terminal autocomplete\n. \"{}\"\n",
+            plugin_dest.display()
+        )
     } else {
         format!(
             "\n# nighthawk — terminal autocomplete\nsource \"{}\"\n",
@@ -162,6 +171,11 @@ pub fn setup_shell(shell: &str) -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
+    // Ensure parent directory exists (e.g. Documents/PowerShell/ on fresh systems)
+    if let Some(parent) = rc_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
     // Append source line
     let mut file = std::fs::OpenOptions::new()
         .create(true)
@@ -171,7 +185,72 @@ pub fn setup_shell(shell: &str) -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Added to {}", rc_path.display());
     println!("\nRestart your shell or run:");
-    println!("  source {}", rc_path.display());
+    if shell == "powershell" || shell == "pwsh" {
+        println!("  . \"{}\"", rc_path.display());
+    } else {
+        println!("  source {}", rc_path.display());
+    }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn powershell_shell_info_returns_ps1_plugin() {
+        let (filename, _) = shell_info("powershell").unwrap();
+        assert_eq!(filename, "nighthawk.ps1");
+    }
+
+    #[test]
+    fn pwsh_shell_info_returns_ps1_plugin() {
+        let (filename, _) = shell_info("pwsh").unwrap();
+        assert_eq!(filename, "nighthawk.ps1");
+    }
+
+    #[test]
+    fn powershell_and_pwsh_return_same_result() {
+        let (file1, path1) = shell_info("powershell").unwrap();
+        let (file2, path2) = shell_info("pwsh").unwrap();
+        assert_eq!(file1, file2);
+        assert_eq!(path1, path2);
+    }
+
+    #[test]
+    fn powershell_profile_path_ends_correctly() {
+        let (_, path) = shell_info("powershell").unwrap();
+        let path_str = path.to_string_lossy();
+        assert!(
+            path_str.contains("PowerShell")
+                && path_str.contains("Microsoft.PowerShell_profile.ps1"),
+            "Unexpected profile path: {path_str}"
+        );
+    }
+
+    #[test]
+    fn powershell_source_line_uses_dot_source() {
+        let plugin_path = PathBuf::from(r"C:\Users\test\nighthawk.ps1");
+        let source_line = format!(
+            "\n# nighthawk — terminal autocomplete\n. \"{}\"\n",
+            plugin_path.display()
+        );
+        assert!(source_line.contains(". \""), "Should use dot-source syntax");
+        assert!(
+            !source_line.contains("source "),
+            "Should not use bash source syntax"
+        );
+    }
+
+    #[test]
+    fn unknown_shell_returns_error() {
+        assert!(shell_info("nushell_unknown").is_err());
+    }
+
+    #[test]
+    fn zsh_still_works() {
+        let (filename, _) = shell_info("zsh").unwrap();
+        assert_eq!(filename, "nighthawk.zsh");
+    }
 }

--- a/crates/nighthawk-daemon/tests/integration.rs
+++ b/crates/nighthawk-daemon/tests/integration.rs
@@ -182,6 +182,83 @@ async fn unknown_command_returns_empty() {
 }
 
 #[tokio::test]
+async fn powershell_shell_variant_works() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let git_spec = include_str!("../../../specs/git.json");
+    std::fs::write(dir.path().join("git.json"), git_spec).unwrap();
+
+    let engine = build_spec_engine(dir.path());
+    let socket_path = format!("{}-pwsh", test_socket_path());
+
+    let engine_clone = Arc::clone(&engine);
+    let sp = socket_path.clone();
+    tokio::spawn(async move {
+        let _ = nighthawk_daemon::server::run(engine_clone, &sp).await;
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Request with PowerShell shell and Windows-style path
+    let resp = query(
+        &socket_path,
+        &CompletionRequest {
+            input: "git ch".into(),
+            cursor: 6,
+            cwd: PathBuf::from(r"D:\projects\nighthawk"),
+            shell: Shell::PowerShell,
+        },
+    )
+    .await;
+
+    assert!(
+        !resp.suggestions.is_empty(),
+        "PowerShell requests should work like any other shell"
+    );
+    assert_eq!(resp.suggestions[0].text, "checkout");
+}
+
+#[tokio::test]
+async fn powershell_fuzzy_match_returns_diff_ops() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let git_spec = include_str!("../../../specs/git.json");
+    std::fs::write(dir.path().join("git.json"), git_spec).unwrap();
+
+    let engine = build_spec_engine(dir.path());
+    let socket_path = format!("{}-pwsh-fuzzy", test_socket_path());
+
+    let engine_clone = Arc::clone(&engine);
+    let sp = socket_path.clone();
+    tokio::spawn(async move {
+        let _ = nighthawk_daemon::server::run(engine_clone, &sp).await;
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Typo: "chekout" instead of "checkout"
+    let resp = query(
+        &socket_path,
+        &CompletionRequest {
+            input: "git chekout".into(),
+            cursor: 11,
+            cwd: PathBuf::from(r"C:\Users\test"),
+            shell: Shell::PowerShell,
+        },
+    )
+    .await;
+
+    assert!(
+        !resp.suggestions.is_empty(),
+        "Fuzzy match should find 'checkout' for 'chekout'"
+    );
+    let first = &resp.suggestions[0];
+    assert_eq!(first.text, "checkout");
+    assert!(
+        first.diff_ops.is_some(),
+        "Fuzzy match should include diff_ops"
+    );
+}
+
+#[tokio::test]
 async fn history_tier_prefix_match() {
     let dir = tempfile::TempDir::new().unwrap();
 

--- a/crates/nighthawk-proto/src/lib.rs
+++ b/crates/nighthawk-proto/src/lib.rs
@@ -220,6 +220,33 @@ mod tests {
     }
 
     #[test]
+    fn powershell_request_with_windows_path() {
+        // Simulates the JSON the PowerShell plugin sends (backslashes escaped)
+        let json = r#"{"input":"cd C:\\Users\\iamsu","cursor":18,"cwd":"D:\\projects\\nighthawk","shell":"powershell"}"#;
+        let parsed: CompletionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.input, r"cd C:\Users\iamsu");
+        assert_eq!(parsed.cursor, 18);
+        assert_eq!(parsed.cwd, PathBuf::from(r"D:\projects\nighthawk"));
+        assert_eq!(parsed.shell, Shell::PowerShell);
+    }
+
+    #[test]
+    fn powershell_request_with_quotes_in_input() {
+        // Input containing escaped double quotes
+        let json = r#"{"input":"echo \"hello world\"","cursor":20,"cwd":"C:\\","shell":"pwsh"}"#;
+        let parsed: CompletionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.input, r#"echo "hello world""#);
+        assert_eq!(parsed.shell, Shell::PowerShell); // pwsh alias
+    }
+
+    #[test]
+    fn powershell_request_unc_path() {
+        let json = r#"{"input":"dir","cursor":3,"cwd":"\\\\server\\share","shell":"powershell"}"#;
+        let parsed: CompletionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.cwd, PathBuf::from(r"\\server\share"));
+    }
+
+    #[test]
     fn suggestion_none_diff_ops_omitted_in_json() {
         // diff_ops: None should not appear in serialized JSON (skip_serializing_if)
         let suggestion = Suggestion {

--- a/shells/nighthawk.ps1
+++ b/shells/nighthawk.ps1
@@ -1,25 +1,191 @@
-# nighthawk PowerShell plugin
+# nighthawk PowerShell plugin — inline ghost text autocomplete
 #
-# Architecture:
-#   Registers a PSReadLine predictor that communicates with the
-#   nighthawk daemon over a named pipe.
-#
-# Install:
-#   Add to $PROFILE: . /path/to/nighthawk.ps1
-#
-# Contract:
-#   1. Connect to daemon named pipe (\\.\pipe\nighthawk)
-#   2. Implement ICommandPredictor interface via PSReadLine
-#   3. On prediction request: send CompletionRequest JSON
-#   4. Read CompletionResponse JSON
-#   5. PSReadLine handles ghost text rendering natively
-#
-# Note: PSReadLine predictors have a 20ms timeout, so only
-# Tier 0 (history) and Tier 1 (specs) are viable here.
+# Install: add to $PROFILE:  . ~/.config/nighthawk/nighthawk.ps1
+# Requires: PSReadLine 2.0+ (ships with PowerShell 5.1+)
 
-# TODO: Implement PSReadLine predictor
-# This requires a compiled C# class implementing ICommandPredictor,
-# or using Set-PSReadLineOption -PredictionSource with a custom handler.
+# --- Initialization ---
+$script:_nh_esc = [char]27
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+# Disable PSReadLine's built-in prediction to avoid overlap with nighthawk ghost text
+try { Set-PSReadLineOption -PredictionSource None } catch {}
 
-# Placeholder: Register inline prediction view
-# Set-PSReadLineOption -PredictionViewStyle InlineView
+# --- Configuration ---
+$script:_nh_hint_arrow = if ($env:NIGHTHAWK_HINT_ARROW) { $env:NIGHTHAWK_HINT_ARROW } else { '→' }
+
+# --- State ---
+$script:_nh_pipe = 'nighthawk'
+$script:_nh_suggestion = ''
+$script:_nh_replace_start = -1
+$script:_nh_replace_end = -1
+$script:_nh_ghost_len = 0
+$script:_nh_last_buffer = ''
+$script:_nh_tried_start = $false
+$script:_nh_backoff_until = [DateTime]::MinValue
+
+# --- Ghost text rendering via ANSI ---
+function _nh_render_ghost([string]$ghost) {
+    if ($ghost.Length -eq 0) { return }
+    $e = $script:_nh_esc
+    $script:_nh_ghost_len = $ghost.Length
+    # Save cursor, gray text, reset color, restore cursor
+    [Console]::Write("${e}[s${e}[90m${ghost}${e}[0m${e}[u")
+}
+
+function _nh_clear_ghost {
+    if ($script:_nh_ghost_len -gt 0) {
+        $e = $script:_nh_esc
+        # Save cursor, clear to end of line, restore cursor
+        [Console]::Write("${e}[s${e}[0K${e}[u")
+        $script:_nh_ghost_len = 0
+    }
+    $script:_nh_suggestion = ''
+    $script:_nh_replace_start = -1
+    $script:_nh_replace_end = -1
+}
+
+# --- Auto-start ---
+function _nh_ensure_daemon {
+    if ($script:_nh_tried_start) { return }
+    $script:_nh_tried_start = $true
+    $nhCmd = Get-Command nh -ErrorAction SilentlyContinue
+    if ($nhCmd) { & nh start 2>$null }
+}
+
+# --- Daemon communication ---
+function _nh_query {
+    $line = ''; $cursor = 0
+    [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$line, [ref]$cursor)
+
+    # Only suggest when cursor is at end and buffer has content
+    if ($cursor -ne $line.Length -or $line.Length -lt 2) { return }
+    if ($line -eq $script:_nh_last_buffer) { return }
+
+    # Backoff: skip queries for 5s after connection failure
+    if ([DateTime]::UtcNow -lt $script:_nh_backoff_until) { return }
+
+    $script:_nh_last_buffer = $line
+
+    try {
+        # Escape for JSON (critical for Windows paths: C:\Users → C:\\Users)
+        $esc_input = $line -replace '\\','\\' -replace '"','\"' -replace "`n",'\n' -replace "`r",'\r'
+        $esc_cwd = $PWD.Path -replace '\\','\\' -replace '"','\"'
+        $json = "{`"input`":`"$esc_input`",`"cursor`":$cursor,`"cwd`":`"$esc_cwd`",`"shell`":`"powershell`"}"
+
+        $pipe = [System.IO.Pipes.NamedPipeClientStream]::new('.', $script:_nh_pipe, [System.IO.Pipes.PipeDirection]::InOut)
+        try {
+            $pipe.Connect(20)
+
+            $utf8 = [System.Text.UTF8Encoding]::new($false)  # UTF-8 without BOM
+            $writer = [System.IO.StreamWriter]::new($pipe, $utf8)
+            $writer.AutoFlush = $true
+            $writer.WriteLine($json)
+
+            $reader = [System.IO.StreamReader]::new($pipe, $utf8)
+            $response = $reader.ReadLine()
+        } finally {
+            $pipe.Dispose()
+        }
+
+        if (-not $response) { return }
+        $parsed = $response | ConvertFrom-Json
+        if (-not $parsed.suggestions -or $parsed.suggestions.Count -eq 0) { return }
+
+        $s = $parsed.suggestions[0]
+        $script:_nh_suggestion = $s.text
+        $script:_nh_replace_start = [int]$s.replace_start
+        $script:_nh_replace_end = [int]$s.replace_end
+
+        if ($s.PSObject.Properties['diff_ops'] -and $null -ne $s.diff_ops) {
+            # Fuzzy match: render as hint " → suggestion"
+            _nh_render_ghost " $($script:_nh_hint_arrow) $($s.text)"
+        } else {
+            # Prefix match: render ghost text suffix
+            $typed_len = $cursor - $script:_nh_replace_start
+            if ($typed_len -ge 0 -and $typed_len -lt $s.text.Length) {
+                _nh_render_ghost $s.text.Substring($typed_len)
+            }
+        }
+    }
+    catch {
+        # Back off for 5s so failed connections don't block typing
+        $script:_nh_backoff_until = [DateTime]::UtcNow.AddSeconds(5)
+        # Try starting the daemon once
+        if (-not $script:_nh_tried_start) { _nh_ensure_daemon }
+    }
+}
+
+# --- Accept suggestion ---
+function _nh_accept {
+    if ($script:_nh_suggestion -and $script:_nh_replace_start -ge 0) {
+        # Save state before _nh_clear_ghost wipes it
+        $text = $script:_nh_suggestion
+        $start = $script:_nh_replace_start
+        $end = $script:_nh_replace_end
+        _nh_clear_ghost
+        $len = $end - $start
+        [Microsoft.PowerShell.PSConsoleReadLine]::Replace($start, $len, $text)
+        $script:_nh_last_buffer = ''
+    }
+}
+
+# --- Key bindings ---
+
+# Handler for printable character input
+$_nh_insert_handler = {
+    param($key, $arg)
+    _nh_clear_ghost
+    [Microsoft.PowerShell.PSConsoleReadLine]::SelfInsert($key, $arg)
+    _nh_query
+}
+
+# Bind common command-line characters (PS 5.1 compat: use int ranges, not char ranges)
+$_nh_bind_chars = @()
+$_nh_bind_chars += 97..122  | ForEach-Object { [string][char]$_ }   # a-z
+$_nh_bind_chars += 65..90   | ForEach-Object { [string][char]$_ }   # A-Z
+$_nh_bind_chars += 48..57   | ForEach-Object { [string][char]$_ }   # 0-9
+$_nh_bind_chars += @('-','_','.','/','\',':','~','=','+','@','#','$','%','^','&','*',',',';','!','|','Spacebar')
+# Deliberately skip: ' " { } ( ) [ ] — preserve PSReadLine SmartInsert/brace-matching
+
+foreach ($c in $_nh_bind_chars) {
+    Set-PSReadLineKeyHandler -Chord $c -ScriptBlock $_nh_insert_handler
+}
+
+Set-PSReadLineKeyHandler -Chord 'Backspace' -ScriptBlock {
+    param($key, $arg)
+    _nh_clear_ghost
+    [Microsoft.PowerShell.PSConsoleReadLine]::BackwardDeleteChar($key, $arg)
+    _nh_query
+}
+
+Set-PSReadLineKeyHandler -Chord 'Tab' -ScriptBlock {
+    param($key, $arg)
+    if ($script:_nh_suggestion) {
+        _nh_accept
+    } else {
+        [Microsoft.PowerShell.PSConsoleReadLine]::TabCompleteNext($key, $arg)
+    }
+}
+
+Set-PSReadLineKeyHandler -Chord 'RightArrow' -ScriptBlock {
+    param($key, $arg)
+    if ($script:_nh_suggestion) {
+        _nh_accept
+    } else {
+        [Microsoft.PowerShell.PSConsoleReadLine]::ForwardChar($key, $arg)
+    }
+}
+
+Set-PSReadLineKeyHandler -Chord 'Enter' -ScriptBlock {
+    param($key, $arg)
+    _nh_clear_ghost
+    [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine($key, $arg)
+}
+
+Set-PSReadLineKeyHandler -Chord 'Escape' -ScriptBlock {
+    param($key, $arg)
+    if ($script:_nh_ghost_len -gt 0) {
+        _nh_clear_ghost
+    } else {
+        [Microsoft.PowerShell.PSConsoleReadLine]::RevertLine($key, $arg)
+    }
+}


### PR DESCRIPTION
## Summary
- **PowerShell plugin** (`shells/nighthawk.ps1`): PSReadLine key handler-based ghost text autocomplete over Windows named pipes. Prefix match ghost text + fuzzy match hint mode (`→ suggestion`).
- **`nh setup powershell`**: Copies plugin to config dir, appends dot-source line to PowerShell 7 profile (`Documents/PowerShell/Microsoft.PowerShell_profile.ps1`), idempotent.
- **12 new tests**: Proto (Windows path escaping, UNC paths, quotes), setup (profile path, dot-source syntax), integration (PowerShell IPC round-trip, fuzzy match diff_ops).

## Key design decisions
- PSReadLine key handlers (not ICommandPredictor C# class) — zero compilation, PS 5.1+ compatible
- UTF-8 without BOM for named pipe StreamWriter (BOM causes daemon JSON parse failure → deadlock)
- 5s backoff after connection failure to prevent typing lag when daemon is down
- Selective key binding (~70 chars) — skips `' " { } ( ) [ ]` to preserve PSReadLine SmartInsert
- `NIGHTHAWK_HINT_ARROW` env var for configurable hint symbol (default `→`)
- `[Console]::OutputEncoding = UTF8` for correct Unicode rendering

## Test plan
- [x] `cargo test` — 123 tests passing (was 111)
- [x] Ghost text appears for `git ch` → gray "eckout"
- [x] Tab accepts suggestion, RightArrow accepts suggestion
- [x] Escape dismisses ghost text without clearing line
- [x] Enter clears ghost and executes command
- [x] Fuzzy hint: `git chekout` → `→ checkout`
- [x] Daemon down: typing is not slow (5s backoff)
- [x] Daemon recovery: suggestions resume after restart
- [x] `nh setup powershell` copies plugin and updates profile
- [x] Setup is idempotent on re-run
- [x] Paste speed is normal

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)