### PR TITLE
fix: update ghost text position on Ctrl+Backspace

### DIFF
--- a/shells/nighthawk.ps1
+++ b/shells/nighthawk.ps1
@@ -191,6 +191,13 @@ Set-PSReadLineKeyHandler -Chord 'Backspace' -ScriptBlock {
     _nh_query
 }
 
+Set-PSReadLineKeyHandler -Chord 'Ctrl+Backspace' -ScriptBlock {
+    param($key, $arg)
+    _nh_clear_ghost
+    [Microsoft.PowerShell.PSConsoleReadLine]::BackwardKillWord($key, $arg)
+    _nh_query
+}
+
 Set-PSReadLineKeyHandler -Chord 'Tab' -ScriptBlock {
     param($key, $arg)
     if ($script:_nh_suggestion) {

--- a/shells/nighthawk.zsh
+++ b/shells/nighthawk.zsh
@@ -139,6 +139,12 @@ _nh_backward_delete() {
 }
 zle -N backward-delete-char _nh_backward_delete
 
+_nh_backward_kill_word() {
+    _nh_restore_before_edit
+    zle .backward-kill-word
+}
+zle -N backward-kill-word _nh_backward_kill_word
+
 _nh_clear_ghost() {
     unset POSTDISPLAY
 


### PR DESCRIPTION
## Summary
- Fixes ghost text remaining at old position when Ctrl+Backspace (word deletion) is pressed
- Adds `backward-kill-word` widget wrapper in zsh plugin
- Adds `Ctrl+Backspace` key handler in PowerShell plugin

## Test plan
- [x] Type command with ghost text visible, press Ctrl+Backspace
- [x] Verify ghost text repositions immediately after cursor
- [x] Test multiple consecutive word deletions
- [x] Test on empty buffer (no-op, no crash)

Closes #55

🤖 Generated with [Claude Code](https://claude.ai/code)