### PR TITLE
feat: show setup hint when shell plugin not detected

### DIFF
--- a/src/cli/daemon_ctl.rs
+++ b/src/cli/daemon_ctl.rs
@@ -95,6 +95,12 @@ pub fn start() -> Result<(), Box<dyn std::error::Error>> {
     if let Some(pid) = read_pid() {
         if is_process_alive(pid) {
             println!("Daemon already running (PID {pid})");
+            // Show setup hint if no plugin installed
+            if !paths::has_any_plugin() {
+                let shell_name = crate::proto::Shell::detect_default().as_str();
+                eprintln!();
+                eprintln!("Hint: Run `nh setup {shell_name}` then restart your shell.");
+            }
             return Ok(());
         }
         // Stale PID file — clean up
@@ -161,6 +167,13 @@ pub fn start() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         println!("Daemon spawned (PID {pid}) but socket not yet ready");
         println!("  Check logs: {}", paths::log_file().display());
+    }
+
+    // Show setup hint if no plugin installed
+    if !paths::has_any_plugin() {
+        let shell_name = crate::proto::Shell::detect_default().as_str();
+        eprintln!();
+        eprintln!("Hint: Run `nh setup {shell_name}` then restart your shell.");
     }
 
     Ok(())
@@ -263,6 +276,13 @@ pub fn status() -> Result<(), Box<dyn std::error::Error>> {
                 println!("Daemon is not running");
             }
         }
+    }
+
+    // Show setup hint if no plugin installed
+    if !paths::has_any_plugin() {
+        let shell_name = crate::proto::Shell::detect_default().as_str();
+        eprintln!();
+        eprintln!("Hint: Run `nh setup {shell_name}` then restart your shell.");
     }
 
     Ok(())

--- a/src/cli/paths.rs
+++ b/src/cli/paths.rs
@@ -24,6 +24,17 @@ pub fn plugin_dir() -> PathBuf {
     config_dir()
 }
 
+/// Check if any shell plugin is installed in the config directory.
+/// Returns true if config_dir is invalid (fallback to ".") to avoid false positive hints.
+pub fn has_any_plugin() -> bool {
+    let dir = config_dir();
+    // If config_dir fell back to ".", don't trust it
+    if dir == PathBuf::from(".") {
+        return true; // Assume setup done, avoid false positive hints
+    }
+    dir.join("nighthawk.zsh").exists() || dir.join("nighthawk.ps1").exists()
+}
+
 /// Standard install directory for nighthawk binaries.
 /// Windows: %LOCALAPPDATA%\Programs\nighthawk\
 /// Unix: ~/.local/bin/


### PR DESCRIPTION
## Summary
- Adds a hint to `nh start` and `nh status` when no shell plugin is installed
- Uses `Shell::detect_default()` to suggest the appropriate shell
- Prints to stderr to avoid breaking scripts

## Example output
```
Daemon started (PID 12345)
  Socket: \.\pipe\nighthawk
  Logs:   C:\Users\...\nighthawk\daemon.log

Hint: Run `nh setup powershell` then restart your shell.
```

## Test plan
- [x] `nh start` with no plugin → hint shown
- [x] `nh status` with no plugin → hint shown  
- [x] `nh start` when "already running" with no plugin → hint shown
- [x] `nh status` with plugin present → no hint
- [x] `cargo test` passes (160 tests)

Closes #57

🤖 Generated with [Claude Code](https://claude.ai/code)