### PR TITLE
fix: clear multi-line ghost text on backspace

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Shell scripts must use LF (Unix line endings)
+*.sh text eol=lf
+*.zsh text eol=lf
+*.bash text eol=lf
+*.fish text eol=lf
+
+# PowerShell can use CRLF (Windows)
+*.ps1 text eol=crlf
+
+# Rust source files
+*.rs text eol=lf
+
+# Config files
+*.toml text eol=lf
+*.json text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf

--- a/shells/nighthawk.ps1
+++ b/shells/nighthawk.ps1
@@ -38,8 +38,8 @@ function _nh_render_ghost([string]$ghost) {
 function _nh_clear_ghost {
     if ($script:_nh_ghost_len -gt 0) {
         $e = $script:_nh_esc
-        # Save cursor, clear to end of line, restore cursor
-        $Host.UI.Write("${e}[s${e}[0K${e}[u")
+        # Save cursor, clear to end of screen (handles wrapped multi-line ghost text), restore cursor
+        $Host.UI.Write("${e}[s${e}[0J${e}[u")
         $script:_nh_ghost_len = 0
     }
     $script:_nh_suggestion = ''

--- a/shells/nighthawk.zsh
+++ b/shells/nighthawk.zsh
@@ -146,6 +146,8 @@ _nh_backward_kill_word() {
 zle -N backward-kill-word _nh_backward_kill_word
 
 _nh_clear_ghost() {
+    # Clear rendered ghost text including wrapped lines (ESC[0J = clear to end of screen)
+    print -n '\e[s\e[0J\e[u'
     unset POSTDISPLAY
 
     # Remove highlight entries we added


### PR DESCRIPTION
## Summary

- Use `ESC[0J` (clear to end of screen) instead of `ESC[0K` (clear to end of line) to handle ghost text that wraps to multiple terminal lines
- Add `.gitattributes` to preserve LF line endings for Unix shell scripts

## Test plan

- [x] PowerShell: type long command, get wrapped ghost text, press backspace — all lines clear
- [x] zsh (WSL): same test passes
- [x] Single-line ghost text still works
- [x] Tab acceptance still works
- [x] Fuzzy hint display still works

Fixes #60

🤖 Generated with [Claude Code](https://claude.ai/code)