### PR TITLE
feat: hot-reload shell history on file change

### DIFF
--- a/src/daemon/engine/history.rs
+++ b/src/daemon/engine/history.rs
@@ -2,7 +2,8 @@ use crate::proto::{CompletionRequest, Suggestion, SuggestionSource};
 use async_trait::async_trait;
 
 use super::tier::PredictionTier;
-use crate::daemon::history::ShellHistory;
+use crate::daemon::history::file::FileHistory;
+use crate::daemon::history::ShellHistory; // Trait must be in scope to call its methods
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -10,11 +11,12 @@ use tokio::sync::RwLock;
 /// Looks up commands the user has typed before, ranked by recency/frequency.
 /// Must complete in under 1ms.
 pub struct HistoryTier {
-    history: Arc<RwLock<dyn ShellHistory>>,
+    // Use concrete FileHistory type to allow calling reload_if_changed()
+    history: Arc<RwLock<FileHistory>>,
 }
 
 impl HistoryTier {
-    pub fn new(history: Arc<RwLock<dyn ShellHistory>>) -> Self {
+    pub fn new(history: Arc<RwLock<FileHistory>>) -> Self {
         Self { history }
     }
 }
@@ -33,6 +35,12 @@ impl PredictionTier for HistoryTier {
         let input = &req.input[..req.cursor];
         if input.is_empty() {
             return vec![];
+        }
+
+        // Check for history file changes before searching (hot-reload)
+        {
+            let mut history = self.history.write().await;
+            history.reload_if_changed();
         }
 
         let history = self.history.read().await;

--- a/src/daemon/history/file.rs
+++ b/src/daemon/history/file.rs
@@ -1,6 +1,7 @@
 use super::{HistoryEntry, ShellHistory};
 use crate::proto::Shell;
 use std::path::PathBuf;
+use std::time::SystemTime;
 
 /// Reads history from shell history files on disk.
 ///
@@ -12,6 +13,10 @@ pub struct FileHistory {
     shell: Shell,
     path: PathBuf,
     entries: Vec<HistoryEntry>,
+    /// File modification time at last load (for change detection)
+    last_modified: Option<SystemTime>,
+    /// File size at last load (for change detection)
+    last_size: u64,
 }
 
 impl FileHistory {
@@ -21,6 +26,8 @@ impl FileHistory {
             shell,
             path,
             entries: Vec::new(),
+            last_modified: None,
+            last_size: 0,
         }
     }
 
@@ -29,6 +36,33 @@ impl FileHistory {
             shell,
             path,
             entries: Vec::new(),
+            last_modified: None,
+            last_size: 0,
+        }
+    }
+
+    /// Check if history file changed since last load, reload if so.
+    /// Returns silently on any error (file locked, inaccessible, etc.) — uses cached results.
+    ///
+    /// Note: There is an inherent TOCTOU race between stat and read. This is acceptable
+    /// because worst case we read newer data but record older metadata, which self-corrects
+    /// on the next request.
+    pub fn reload_if_changed(&mut self) {
+        let meta = match std::fs::metadata(&self.path) {
+            Ok(m) => m,
+            Err(_) => return, // File inaccessible, use cached results
+        };
+
+        let modified = meta.modified().ok();
+        let size = meta.len();
+
+        // Detect change: mtime different OR size different
+        let changed = self.last_modified != modified || self.last_size != size;
+
+        if changed {
+            if let Err(e) = self.load() {
+                tracing::debug!(error = %e, "History reload failed, using stale data");
+            }
         }
     }
 
@@ -111,6 +145,12 @@ impl ShellHistory for FileHistory {
 
         // Sort by frequency (most used first)
         self.entries.sort_by(|a, b| b.frequency.cmp(&a.frequency));
+
+        // Track file state for change detection
+        if let Ok(meta) = std::fs::metadata(&self.path) {
+            self.last_modified = meta.modified().ok();
+            self.last_size = meta.len();
+        }
 
         tracing::debug!(
             shell = ?self.shell,

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -46,7 +46,8 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
         if let Err(e) = file_history.load() {
             tracing::warn!("Failed to load history for {}: {e}", shell.as_str());
         }
-        let history: Arc<tokio::sync::RwLock<dyn history::ShellHistory>> =
+        // Use concrete type to allow hot-reload via reload_if_changed()
+        let history: Arc<tokio::sync::RwLock<history::file::FileHistory>> =
             Arc::new(tokio::sync::RwLock::new(file_history));
         tiers.push(Box::new(engine::history::HistoryTier::new(history)));
         tracing::debug!("History tier enabled");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -273,7 +273,8 @@ async fn history_tier_prefix_match() {
     let mut file_history = FileHistory::with_path(Shell::Bash, history_path);
     file_history.load().unwrap();
 
-    let history: Arc<tokio::sync::RwLock<dyn ShellHistory>> =
+    // Use concrete type to allow hot-reload via reload_if_changed()
+    let history: Arc<tokio::sync::RwLock<FileHistory>> =
         Arc::new(tokio::sync::RwLock::new(file_history));
 
     let tier = HistoryTier::new(history);


### PR DESCRIPTION
## Summary

- Check history file mtime/size before each suggestion search
- Reload history if file changed since last load
- Enables suggestions for commands run after daemon start without restart

## Implementation

- Add `last_modified` and `last_size` tracking fields to `FileHistory`
- Add `reload_if_changed()` method with change detection (`mtime != last || size != last`)
- Call reload check in `HistoryTier::predict()` before searching
- Use concrete `FileHistory` type in tier (not trait object) to access the reload method

## Design decisions

- **Per-request polling over file watcher**: History file changes on every command, but we only need fresh data when showing suggestions. `stat()` call (~0.1ms) is cheaper than maintaining a watcher that fires on every command.
- **Full reload on change**: History files are typically <100KB. Full reload is fast enough, avoids incremental parsing complexity.
- **Silent error handling**: If file is locked/inaccessible, use cached results. Self-corrects on next request.

## Test plan

- [x] `cargo test` — all 167 tests pass
- [x] `cargo clippy` — no warnings
- [x] Manual test: start daemon, run command in shell, verify suggestion appears without restart

Closes #29

🤖 Generated with [Claude Code](https://claude.ai/code)