### PR TITLE
feat: use per-request shell for history tier

### DIFF
--- a/src/daemon/engine/history.rs
+++ b/src/daemon/engine/history.rs
@@ -1,24 +1,63 @@
 use crate::daemon::fuzzy;
-use crate::proto::{CompletionRequest, Suggestion, SuggestionSource};
+use crate::proto::{CompletionRequest, Shell, Suggestion, SuggestionSource};
 use async_trait::async_trait;
 
 use super::tier::PredictionTier;
 use crate::daemon::history::file::FileHistory;
-use crate::daemon::history::ShellHistory; // Trait must be in scope to call its methods
-use std::sync::Arc;
+use crate::daemon::history::ShellHistory;
 use tokio::sync::RwLock;
 
 /// Tier 0: History prefix matching.
 /// Looks up commands the user has typed before, ranked by recency/frequency.
 /// Must complete in under 1ms.
 pub struct HistoryTier {
-    // Use concrete FileHistory type to allow calling reload_if_changed()
-    history: Arc<RwLock<FileHistory>>,
+    histories: RwLock<[FileHistory; 5]>,
+}
+
+impl Default for HistoryTier {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl HistoryTier {
-    pub fn new(history: Arc<RwLock<FileHistory>>) -> Self {
-        Self { history }
+    pub fn new() -> Self {
+        let shells = [
+            Shell::Zsh,
+            Shell::Bash,
+            Shell::Fish,
+            Shell::PowerShell,
+            Shell::Nushell,
+        ];
+        let histories: [FileHistory; 5] = std::array::from_fn(|i| {
+            let mut h = FileHistory::new(shells[i]);
+            if let Err(e) = h.load() {
+                tracing::debug!(shell = shells[i].as_str(), error = %e, "No history file");
+            }
+            h
+        });
+        Self {
+            histories: RwLock::new(histories),
+        }
+    }
+
+    /// Create a HistoryTier with a single pre-loaded history.
+    /// Other shells will have empty histories. Useful for testing.
+    pub fn with_history(history: FileHistory) -> Self {
+        let shell = history.shell();
+        let idx = shell.index();
+        let shells = [
+            Shell::Zsh,
+            Shell::Bash,
+            Shell::Fish,
+            Shell::PowerShell,
+            Shell::Nushell,
+        ];
+        let mut histories: [FileHistory; 5] = std::array::from_fn(|i| FileHistory::new(shells[i]));
+        histories[idx] = history;
+        Self {
+            histories: RwLock::new(histories),
+        }
     }
 }
 
@@ -38,14 +77,16 @@ impl PredictionTier for HistoryTier {
             return vec![];
         }
 
+        let idx = req.shell.index();
+
         // Check for history file changes before searching (hot-reload)
         {
-            let mut history = self.history.write().await;
-            history.reload_if_changed();
+            let mut histories = self.histories.write().await;
+            histories[idx].reload_if_changed();
         }
 
-        let history = self.history.read().await;
-        let entries = history.search_prefix(input, 5);
+        let histories = self.histories.read().await;
+        let entries = histories[idx].search_prefix(input, 5);
 
         if !entries.is_empty() {
             // Fast path: exact prefix match
@@ -67,7 +108,7 @@ impl PredictionTier for HistoryTier {
         }
 
         // Fuzzy fallback: try correcting the first token
-        Self::try_fuzzy_fallback(input, &history)
+        Self::try_fuzzy_fallback(input, &histories[idx])
     }
 }
 

--- a/src/daemon/history/file.rs
+++ b/src/daemon/history/file.rs
@@ -41,6 +41,10 @@ impl FileHistory {
         }
     }
 
+    pub fn shell(&self) -> Shell {
+        self.shell
+    }
+
     /// Check if history file changed since last load, reload if so.
     /// Returns silently on any error (file locked, inaccessible, etc.) — uses cached results.
     ///

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -5,9 +5,7 @@ pub mod history;
 pub mod server;
 pub mod specs;
 
-use crate::proto::Shell;
 use engine::PredictionEngine;
-use history::ShellHistory;
 use std::sync::Arc;
 use tracing_subscriber::EnvFilter;
 
@@ -29,28 +27,10 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // Build prediction tiers
     let mut tiers: Vec<Box<dyn engine::tier::PredictionTier>> = Vec::new();
 
-    // Tier 0: History
+    // Tier 0: History (loads all shells eagerly, selects per-request via req.shell)
     if config.tiers.enable_history {
-        // TODO: support multi-shell history — lazily load per-shell keyed by req.shell
-        let shell = Shell::detect_default();
-        if let Ok(val) = std::env::var("NIGHTHAWK_SHELL") {
-            if val.trim().parse::<Shell>().is_err() {
-                tracing::warn!(
-                    "NIGHTHAWK_SHELL={val} is not recognized, falling back to {}",
-                    shell.as_str()
-                );
-            }
-        }
-        tracing::info!("Default shell for history: {}", shell.as_str());
-        let mut file_history = history::file::FileHistory::new(shell);
-        if let Err(e) = file_history.load() {
-            tracing::warn!("Failed to load history for {}: {e}", shell.as_str());
-        }
-        // Use concrete type to allow hot-reload via reload_if_changed()
-        let history: Arc<tokio::sync::RwLock<history::file::FileHistory>> =
-            Arc::new(tokio::sync::RwLock::new(file_history));
-        tiers.push(Box::new(engine::history::HistoryTier::new(history)));
-        tracing::debug!("History tier enabled");
+        tiers.push(Box::new(engine::history::HistoryTier::new()));
+        tracing::debug!("History tier enabled (multi-shell)");
     }
 
     // Tier 1: Specs

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -48,6 +48,16 @@ impl Shell {
         }
     }
 
+    pub fn index(&self) -> usize {
+        match self {
+            Shell::Zsh => 0,
+            Shell::Bash => 1,
+            Shell::Fish => 2,
+            Shell::PowerShell => 3,
+            Shell::Nushell => 4,
+        }
+    }
+
     /// Detect default shell from env vars + platform.
     ///
     /// Priority:

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -273,11 +273,7 @@ async fn history_tier_prefix_match() {
     let mut file_history = FileHistory::with_path(Shell::Bash, history_path);
     file_history.load().unwrap();
 
-    // Use concrete type to allow hot-reload via reload_if_changed()
-    let history: Arc<tokio::sync::RwLock<FileHistory>> =
-        Arc::new(tokio::sync::RwLock::new(file_history));
-
-    let tier = HistoryTier::new(history);
+    let tier = HistoryTier::with_history(file_history);
     let engine = Arc::new(PredictionEngine::new(vec![Box::new(tier)]));
 
     let socket_path = format!("{}-history", test_socket_path());


### PR DESCRIPTION
## Summary

- Daemon now loads all 5 shells' histories at startup
- Uses `req.shell` from each `CompletionRequest` to select appropriate history
- Fixes cross-shell contamination (e.g., starting daemon from bash but using zsh)

## Changes

- Add `Shell::index()` for O(1) array lookup
- Change `HistoryTier` from single `FileHistory` to `[FileHistory; 5]`
- Eager load all shells at startup (~20ms total)
- Simplify daemon startup (remove `Shell::detect_default()` call)

## Test plan

- [x] `cargo test` passes (188 tests)
- [x] Manual test: start daemon, verify zsh gets zsh history, bash gets bash history
- [x] Verified no cross-shell contamination

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)