### PR TITLE
feat: tier 3 cloud LLM (OpenAI / Anthropic / Groq, BYOK)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,7 @@ pub trait ShellHistory: Send + Sync {
 - **Never use platform-specific IPC directly** — use `interprocess` crate abstractions
 - **Never expose HTTP/REST** — IPC only, the daemon is not a web server. (Outbound HTTP for LLM tiers is OK behind a feature flag.)
 - **Never block the IPC server** — async all the way, slow tiers must not starve fast ones
+- **Never block the input loop in shell plugins** — synchronous IPC must run off the keystroke thread. PowerShell gotcha: `Register-ObjectEvent -Action` is pumped on the main pipeline thread; spawn work via `[PowerShell]::Create().BeginInvoke()` against a pre-opened `RunspacePool`. A raw `[System.Threading.Thread]` needs a Runspace in TLS or the CLR fast-fails the whole process (0xE0434352).
 
 ## Design decisions
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ path = "src/bin/nighthawk_daemon.rs"
 [features]
 default = []
 local-llm = ["reqwest"]
+cloud-llm = ["reqwest"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ Type a command, see gray ghost text with the completion. Press Tab to accept. No
 ## Features
 
 - **Inline ghost text** via ANSI escapes — works in any terminal emulator
-- **500+ CLI specs** from the [withfig/autocomplete](https://github.com/withfig/autocomplete) community repo
+- **689+ CLI specs** from the [withfig/autocomplete](https://github.com/withfig/autocomplete) community repo
 - **Auto-parse `--help`** for any CLI without a spec
 - **History-based predictions** — your most-used commands surface first
 - **Full-token replacement** — typo-aware (`ccla` → `claude`, not `cclaude`)
 - **Zero config** — works immediately with no API key, no login, no account
 - **Cross-platform** — macOS, Linux, Windows
-- **Multi-shell** — zsh, bash, fish, PowerShell
-- **Local LLM support** *(coming soon)* — AI completions that never leave your machine
-- **BYOK cloud** *(coming soon)* — bring your own API key for OpenAI, Anthropic, etc.
+- **Multi-shell** — zsh and PowerShell (5.1+, 7+)
+- **Local LLM support** — AI completions via local Ollama / llama.cpp / vLLM, never leave your machine (opt-in via `--features local-llm`)
+- **BYOK cloud** — bring your own API key for OpenAI, Anthropic, or Groq (opt-in via `--features cloud-llm`)
 
 ## Architecture
 
@@ -29,8 +29,8 @@ Lightweight Rust daemon + thin shell plugins (~50 lines each). The daemon runs a
 |------|---------|--------|
 | 0 | <1ms | Shell history prefix matching |
 | 1 | <1ms | Static CLI specs (withfig/autocomplete + --help parser) |
-| 2 | ~50ms | Local LLM (future) |
-| 3 | ~500ms | Cloud API, BYOK (future) |
+| 2 | ~500ms | Local LLM (Ollama / llama.cpp / vLLM) |
+| 3 | ~2s | Cloud API (OpenAI / Anthropic / Groq, BYOK) |
 
 ## Status
 
@@ -38,17 +38,17 @@ Lightweight Rust daemon + thin shell plugins (~50 lines each). The daemon runs a
 
 | Shell | Status |
 |-------|--------|
-| zsh | In progress |
+| zsh | Supported |
+| PowerShell (5.1+, 7+) | Supported |
 | bash | Planned |
 | fish | Planned |
-| PowerShell | Planned |
 | nushell | Planned |
 
 | Platform | Status |
 |----------|--------|
-| macOS | In progress |
-| Linux | In progress |
-| Windows | Planned |
+| macOS | Supported |
+| Linux | Supported |
+| Windows | Supported |
 
 ## License
 

--- a/shells/nighthawk.ps1
+++ b/shells/nighthawk.ps1
@@ -13,242 +13,280 @@ try { Set-PSReadLineOption -PredictionSource None } catch {}
 # Env vars override config file values.
 function _nh_load_plugin_config {
     $settings = @{
-        timeout_ms = 100
+        debounce_ms = 200
         hint_arrow = '->'
+        debug = $false
     }
     $configPath = Join-Path $env:APPDATA "nighthawk\config.toml"
     if (Test-Path $configPath) {
         try {
             $content = Get-Content $configPath -Raw -ErrorAction Stop
-            # Extract [plugin] section only (until next section or EOF)
             if ($content -match '(?ms)^\[plugin\]\s*(.*?)(?=^\[|\z)') {
                 $section = $matches[1]
-                if ($section -match '(?m)^\s*timeout_ms\s*=\s*(\d+)') {
-                    $settings.timeout_ms = [int]$matches[1]
+                if ($section -match '(?m)^\s*debounce_ms\s*=\s*(\d+)') {
+                    $settings.debounce_ms = [int]$matches[1]
                 }
                 if ($section -match '(?m)^\s*hint_arrow\s*=\s*"([^"]*)"') {
                     $settings.hint_arrow = $matches[1]
                 }
+                if ($section -match '(?m)^\s*debug\s*=\s*(true|false)') {
+                    $settings.debug = ($matches[1] -eq 'true')
+                }
             }
-        } catch {
-            # Silently ignore config read errors — use defaults
-        }
+        } catch {}
     }
     return $settings
 }
 
 $script:_nh_config = _nh_load_plugin_config
 $script:_nh_hint_arrow = if ($env:NIGHTHAWK_HINT_ARROW) { $env:NIGHTHAWK_HINT_ARROW } else { $script:_nh_config.hint_arrow }
-$script:_nh_timeout_ms = if ($env:NIGHTHAWK_TIMEOUT_MS) { [int]$env:NIGHTHAWK_TIMEOUT_MS } else { $script:_nh_config.timeout_ms }
+$script:_nh_debounce_ms = if ($env:NIGHTHAWK_DEBOUNCE_MS) { [int]$env:NIGHTHAWK_DEBOUNCE_MS } else { $script:_nh_config.debounce_ms }
+$script:_nh_debug = if ($env:NIGHTHAWK_DEBUG) { $env:NIGHTHAWK_DEBUG -eq '1' } else { $script:_nh_config.debug }
+$script:_nh_log_path = Join-Path $env:APPDATA "nighthawk\plugin.log"
 
-# --- State ---
-$script:_nh_pipe = 'nighthawk'
-$script:_nh_suggestion = ''
-$script:_nh_replace_start = -1
-$script:_nh_replace_end = -1
-$script:_nh_ghost_len = 0
-$script:_nh_last_buffer = ''
-$script:_nh_tried_start = $false
-$script:_nh_backoff_until = [DateTime]::MinValue
+# --- Diagnostic logging (only when debug enabled) ---
+# Thread-safe via append; can be called from foreground or background.
+function _nh_log {
+    param([string]$msg)
+    if (-not $script:_nh_debug) { return }
+    try {
+        $ts = (Get-Date).ToString('HH:mm:ss.fff')
+        $tid = [System.Threading.Thread]::CurrentThread.ManagedThreadId
+        Add-Content -Path $script:_nh_log_path -Value "$ts t$tid $msg" -ErrorAction SilentlyContinue
+    } catch {}
+}
 
-# Async pending query state (for cloud-tier slow responses)
-$script:_nh_pending_pipe = $null
-$script:_nh_pending_task = $null
-$script:_nh_pending_buffer = ''
-$script:_nh_pending_cursor = 0
-$script:_nh_last_query_at = [DateTime]::MinValue
-# Minimum ms between queries (throttle to prevent hammering daemon while typing)
-$script:_nh_throttle_ms = 150
-# How long to wait synchronously for response (fast tiers respond quickly)
-$script:_nh_quick_wait_ms = [Math]::Min($script:_nh_timeout_ms, 150)
+# --- Synchronized shared state (accessed across threads) ---
+# Foreground reads/writes via $script:_nh_state.X
+# Background timer Action reads/writes via $Event.MessageData.X (same hashtable instance)
+$script:_nh_state = [hashtable]::Synchronized(@{
+    pipe_name      = 'nighthawk'
+    debounce_ms    = $script:_nh_debounce_ms
+    hint_arrow     = $script:_nh_hint_arrow
+    debug          = $script:_nh_debug
+    log_path       = $script:_nh_log_path
+    esc            = [char]27
+    # Per-keystroke captured state
+    pending_buffer = ''
+    pending_cursor = 0
+    generation     = 0
+    # Currently-displayed ghost suggestion (read by accept handler)
+    suggestion     = ''
+    replace_start  = -1
+    replace_end    = -1
+    ghost_len      = 0
+})
 
 # --- Ghost text rendering via ANSI ---
+# Uses [Console]::Write so it's safe to call from any thread.
 function _nh_render_ghost([string]$ghost) {
     if ($ghost.Length -eq 0) { return }
     $e = $script:_nh_esc
-    $script:_nh_ghost_len = $ghost.Length
-    # Save cursor, gray text, reset color, restore cursor
-    # Strip double quotes — Windows Terminal renders them as "" inside ANSI regions
     $clean = $ghost -replace '"', ''
-    $script:_nh_ghost_len = $clean.Length
-    $Host.UI.Write("${e}[s${e}[90m")
-    $Host.UI.Write($clean)
-    $Host.UI.Write("${e}[0m${e}[u")
+    $script:_nh_state.ghost_len = $clean.Length
+    [System.Console]::Write("${e}[s${e}[90m${clean}${e}[0m${e}[u")
 }
 
 function _nh_clear_ghost {
-    if ($script:_nh_ghost_len -gt 0) {
+    if ($script:_nh_state.ghost_len -gt 0) {
         $e = $script:_nh_esc
-        # Save cursor, clear to end of screen (handles wrapped multi-line ghost text), restore cursor
-        $Host.UI.Write("${e}[s${e}[0J${e}[u")
-        $script:_nh_ghost_len = 0
+        [System.Console]::Write("${e}[s${e}[0J${e}[u")
+        $script:_nh_state.ghost_len = 0
     }
-    $script:_nh_suggestion = ''
-    $script:_nh_replace_start = -1
-    $script:_nh_replace_end = -1
+    $script:_nh_state.suggestion = ''
+    $script:_nh_state.replace_start = -1
+    $script:_nh_state.replace_end = -1
 }
 
 # --- Auto-start ---
+$script:_nh_tried_start = $false
+$script:_nh_backoff_until = [DateTime]::MinValue
 function _nh_ensure_daemon {
     if ($script:_nh_tried_start) { return }
     $script:_nh_tried_start = $true
     $nhCmd = Get-Command nh -ErrorAction SilentlyContinue
     if ($nhCmd) {
-        # Start asynchronously — nh start calls tasklist which blocks 1-3s on Windows.
-        # Must not block the PSReadLine key handler or input freezes.
         Start-Process nh -ArgumentList 'start' -WindowStyle Hidden
     }
 }
 
-# --- Render a response (shared between sync and async paths) ---
-function _nh_render_response {
-    param([string]$response, [string]$line, [int]$cursor)
-    if (-not $response) { return }
+# --- Debounce timer + ROE event subscriber ---
+# Register-ObjectEvent runs the -Action in PowerShell's event-handler runspace.
+# That runspace cannot see this script's functions or $script: vars, so:
+#   - State is shared via -MessageData (synchronized hashtable, by reference)
+#   - Daemon IPC + render logic is INLINED in the Action block
+#   - All ANSI output goes through [Console]::Write (thread-safe)
+$script:_nh_timer = [System.Timers.Timer]::new()
+$script:_nh_timer.AutoReset = $false
+$script:_nh_timer.Interval = $script:_nh_debounce_ms
+
+# Cleanup any previous registration if plugin is re-sourced
+Get-EventSubscriber -SourceIdentifier 'nh_debounce' -ErrorAction SilentlyContinue | Unregister-Event -ErrorAction SilentlyContinue
+
+$null = Register-ObjectEvent -InputObject $script:_nh_timer -EventName Elapsed `
+    -SourceIdentifier 'nh_debounce' -MessageData $script:_nh_state -Action {
+    $state = $Event.MessageData
+
+    # Inline diagnostic log (can't call _nh_log from this runspace)
+    $writeLog = {
+        param([string]$m)
+        if (-not $state.debug) { return }
+        try {
+            $ts = (Get-Date).ToString('HH:mm:ss.fff')
+            $tid = [System.Threading.Thread]::CurrentThread.ManagedThreadId
+            Add-Content -Path $state.log_path -Value "$ts t$tid [bg] $m" -ErrorAction SilentlyContinue
+        } catch {}
+    }
+
+    & $writeLog "Elapsed fired (gen=$($state.generation), buf='$($state.pending_buffer)')"
+
     try {
-        $parsed = $response | ConvertFrom-Json
-    } catch { return }
-    if (-not $parsed.suggestions -or $parsed.suggestions.Count -eq 0) { return }
+        $myGen = $state.generation
+        $line = $state.pending_buffer
+        $cursor = $state.pending_cursor
 
-    $s = $parsed.suggestions[0]
-    $script:_nh_suggestion = $s.text
-    $script:_nh_replace_start = [int]$s.replace_start
-    $script:_nh_replace_end = [int]$s.replace_end
+        if (-not $line -or $line.Length -lt 2) {
+            & $writeLog "skip: empty/short buffer"
+            return
+        }
 
-    if ($s.PSObject.Properties['diff_ops'] -and $null -ne $s.diff_ops) {
-        _nh_render_ghost " $($script:_nh_hint_arrow) $($s.text)"
-    } else {
-        $typed_len = $cursor - $script:_nh_replace_start
-        if ($typed_len -ge 0 -and $typed_len -lt $s.text.Length) {
-            $typed_part = $line.Substring($script:_nh_replace_start, $typed_len)
-            if ($s.text.StartsWith($typed_part, [System.StringComparison]::Ordinal)) {
-                _nh_render_ghost $s.text.Substring($typed_len)
-            } else {
-                _nh_render_ghost " $($script:_nh_hint_arrow) $($s.text)"
+        $pipePath = "\\.\pipe\$($state.pipe_name)"
+        if (-not (Test-Path $pipePath)) {
+            & $writeLog "skip: pipe missing at $pipePath"
+            return
+        }
+
+        # Build JSON request (escape Windows backslashes, quotes, newlines)
+        $esc_input = $line -replace '\\','\\' -replace '"','\"' -replace "`n",'\n' -replace "`r",'\r'
+        $esc_cwd = $PWD.Path -replace '\\','\\' -replace '"','\"'
+        $json = "{`"input`":`"$esc_input`",`"cursor`":$cursor,`"cwd`":`"$esc_cwd`",`"shell`":`"powershell`"}"
+
+        & $writeLog "sending request len=$($line.Length)"
+
+        # Synchronous IPC — daemon enforces tier budgets so this is bounded
+        $pipe = [System.IO.Pipes.NamedPipeClientStream]::new('.', $state.pipe_name, [System.IO.Pipes.PipeDirection]::InOut)
+        $response = $null
+        try {
+            $pipe.Connect(50)
+            $utf8 = [System.Text.UTF8Encoding]::new($false)
+            $writer = [System.IO.StreamWriter]::new($pipe, $utf8)
+            $writer.AutoFlush = $true
+            $writer.WriteLine($json)
+            $reader = [System.IO.StreamReader]::new($pipe, $utf8)
+            $response = $reader.ReadLine()
+        } finally {
+            $pipe.Dispose()
+        }
+
+        if (-not $response) {
+            & $writeLog "empty response"
+            return
+        }
+
+        # Staleness check — abort if user typed during the daemon call
+        if ($state.generation -ne $myGen) {
+            & $writeLog "stale (gen advanced $myGen -> $($state.generation))"
+            return
+        }
+
+        # Parse response
+        $parsed = $null
+        try { $parsed = $response | ConvertFrom-Json } catch {
+            & $writeLog "parse fail: $($_.Exception.Message)"
+            return
+        }
+        if (-not $parsed.suggestions -or $parsed.suggestions.Count -eq 0) {
+            & $writeLog "no suggestions"
+            return
+        }
+
+        $s = $parsed.suggestions[0]
+        $state.suggestion = $s.text
+        $state.replace_start = [int]$s.replace_start
+        $state.replace_end = [int]$s.replace_end
+
+        # Compute ghost text
+        $ghost = $null
+        if ($s.PSObject.Properties['diff_ops'] -and $null -ne $s.diff_ops) {
+            $ghost = " $($state.hint_arrow) $($s.text)"
+        } else {
+            $typed_len = $cursor - [int]$s.replace_start
+            if ($typed_len -ge 0 -and $typed_len -lt $s.text.Length) {
+                $typed_part = $line.Substring([int]$s.replace_start, $typed_len)
+                if ($s.text.StartsWith($typed_part, [System.StringComparison]::Ordinal)) {
+                    $ghost = $s.text.Substring($typed_len)
+                } else {
+                    $ghost = " $($state.hint_arrow) $($s.text)"
+                }
             }
         }
-    }
-}
 
-# --- Check if a previous async query completed ---
-function _nh_check_pending {
-    if (-not $script:_nh_pending_task) { return }
-    if (-not $script:_nh_pending_task.IsCompleted) { return }
-
-    try {
-        $response = $script:_nh_pending_task.Result
-
-        # Get current buffer - only render if it still matches what we queried for
-        $cur_line = ''; $cur_cursor = 0
-        [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$cur_line, [ref]$cur_cursor)
-        if ($cur_line -eq $script:_nh_pending_buffer -and $cur_cursor -eq $cur_line.Length) {
-            _nh_render_response $response $cur_line $cur_cursor
+        if (-not $ghost) {
+            & $writeLog "no ghost computed"
+            return
         }
-    } catch {}
 
-    _nh_cleanup_pending
-}
+        $clean = $ghost -replace '"', ''
+        $state.ghost_len = $clean.Length
 
-function _nh_cleanup_pending {
-    if ($script:_nh_pending_pipe) {
-        try { $script:_nh_pending_pipe.Dispose() } catch {}
+        # Render via [Console]::Write — thread-safe, bypasses runspace $Host
+        $e = $state.esc
+        [System.Console]::Write("${e}[s${e}[90m${clean}${e}[0m${e}[u")
+        & $writeLog "rendered ghost (len=$($clean.Length))"
+    } catch {
+        & $writeLog "EXCEPTION: $($_.Exception.Message)"
     }
-    $script:_nh_pending_pipe = $null
-    $script:_nh_pending_task = $null
-    $script:_nh_pending_buffer = ''
-    $script:_nh_pending_cursor = 0
 }
 
-# --- Daemon communication ---
+# --- Schedule debounced query ---
 function _nh_query {
-    # First: check if a previous async query completed (may render ghost text)
-    _nh_check_pending
-
     $line = ''; $cursor = 0
     [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$line, [ref]$cursor)
 
-    # Only suggest when cursor is at end and buffer has content
+    _nh_log "_nh_query: line='$line' cursor=$cursor"
+
     if ($cursor -ne $line.Length -or $line.Length -lt 2) { return }
-    if ($line -eq $script:_nh_last_buffer) { return }
 
-    # Throttle: skip if we queried too recently (prevents hammering daemon while typing)
-    $elapsed = ([DateTime]::UtcNow - $script:_nh_last_query_at).TotalMilliseconds
-    if ($elapsed -lt $script:_nh_throttle_ms) { return }
+    if ([DateTime]::UtcNow -lt $script:_nh_backoff_until) {
+        _nh_log "_nh_query: in backoff window"
+        return
+    }
 
-    # Backoff: skip queries for 5s after connection failure
-    if ([DateTime]::UtcNow -lt $script:_nh_backoff_until) { return }
-
-    # Fast check: bail if the named pipe doesn't exist.
-    if (-not (Test-Path "\\.\pipe\$($script:_nh_pipe)")) {
+    if (-not (Test-Path "\\.\pipe\$($script:_nh_state.pipe_name)")) {
+        _nh_log "_nh_query: pipe missing, setting backoff"
         $script:_nh_backoff_until = [DateTime]::UtcNow.AddSeconds(5)
         if (-not $script:_nh_tried_start) { _nh_ensure_daemon }
         return
     }
 
-    $script:_nh_last_buffer = $line
-    $script:_nh_last_query_at = [DateTime]::UtcNow
+    # Capture state for the timer Elapsed callback
+    $script:_nh_state.pending_buffer = $line
+    $script:_nh_state.pending_cursor = $cursor
+    $script:_nh_state.generation++
 
-    # Cancel any in-progress query (user typed again, previous is stale)
-    _nh_cleanup_pending
+    # Reset debounce window
+    $script:_nh_timer.Stop()
+    $script:_nh_timer.Start()
 
-    try {
-        # Escape for JSON (critical for Windows paths: C:\Users → C:\\Users)
-        $esc_input = $line -replace '\\','\\' -replace '"','\"' -replace "`n",'\n' -replace "`r",'\r'
-        $esc_cwd = $PWD.Path -replace '\\','\\' -replace '"','\"'
-        $json = "{`"input`":`"$esc_input`",`"cursor`":$cursor,`"cwd`":`"$esc_cwd`",`"shell`":`"powershell`"}"
-
-        $pipe = [System.IO.Pipes.NamedPipeClientStream]::new('.', $script:_nh_pipe, [System.IO.Pipes.PipeDirection]::InOut)
-        $pipe.Connect(20)
-
-        $utf8 = [System.Text.UTF8Encoding]::new($false)
-        $writer = [System.IO.StreamWriter]::new($pipe, $utf8)
-        $writer.AutoFlush = $true
-        $writer.WriteLine($json)
-
-        $reader = [System.IO.StreamReader]::new($pipe, $utf8)
-        $readTask = $reader.ReadLineAsync()
-
-        # Quick sync wait - fast tiers (history, specs) respond in <50ms
-        if ($readTask.Wait($script:_nh_quick_wait_ms)) {
-            # Fast response - render immediately
-            $response = $readTask.Result
-            $pipe.Dispose()
-            _nh_render_response $response $line $cursor
-        } else {
-            # Slow response (cloud tier) - store task, check on next keystroke
-            $script:_nh_pending_pipe = $pipe
-            $script:_nh_pending_task = $readTask
-            $script:_nh_pending_buffer = $line
-            $script:_nh_pending_cursor = $cursor
-        }
-    }
-    catch {
-        $script:_nh_backoff_until = [DateTime]::UtcNow.AddSeconds(5)
-        _nh_cleanup_pending
-    }
+    _nh_log "_nh_query: timer reset (gen=$($script:_nh_state.generation))"
 }
 
 # --- Accept suggestion ---
 function _nh_accept {
-    if ($script:_nh_suggestion -and $script:_nh_replace_start -ge 0) {
-        # Save state before _nh_clear_ghost wipes it
-        $text = $script:_nh_suggestion
-        $start = $script:_nh_replace_start
-        $end = $script:_nh_replace_end
+    if ($script:_nh_state.suggestion -and $script:_nh_state.replace_start -ge 0) {
+        $text = $script:_nh_state.suggestion
+        $start = $script:_nh_state.replace_start
+        $end = $script:_nh_state.replace_end
         _nh_clear_ghost
         $len = $end - $start
         [Microsoft.PowerShell.PSConsoleReadLine]::Replace($start, $len, $text)
-        $script:_nh_last_buffer = ''
     }
 }
 
 # --- Key bindings ---
 
-# Handler for printable character input
 $_nh_insert_handler = {
     param($key, $arg)
-    # Pass through immediately when Ctrl/Alt modifiers are held.
-    # Prevents blocking during control sequences which can interfere with
-    # Windows Console modifier key tracking on some systems (issue #58).
     if ($key.Modifiers -band [System.ConsoleModifiers]::Control -or
         $key.Modifiers -band [System.ConsoleModifiers]::Alt) {
         [Microsoft.PowerShell.PSConsoleReadLine]::SelfInsert($key, $arg)
@@ -259,11 +297,10 @@ $_nh_insert_handler = {
     _nh_query
 }
 
-# Bind common command-line characters (PS 5.1 compat: use int ranges, not char ranges)
 $_nh_bind_chars = @()
-$_nh_bind_chars += 97..122  | ForEach-Object { [string][char]$_ }   # a-z
-$_nh_bind_chars += 65..90   | ForEach-Object { [string][char]$_ }   # A-Z
-$_nh_bind_chars += 48..57   | ForEach-Object { [string][char]$_ }   # 0-9
+$_nh_bind_chars += 97..122  | ForEach-Object { [string][char]$_ }
+$_nh_bind_chars += 65..90   | ForEach-Object { [string][char]$_ }
+$_nh_bind_chars += 48..57   | ForEach-Object { [string][char]$_ }
 $_nh_bind_chars += @('-','_','.','/','\',':','~','=','+','@','#','$','%','^','&','*',',',';','!','|','Spacebar')
 
 foreach ($c in $_nh_bind_chars) {
@@ -286,7 +323,7 @@ Set-PSReadLineKeyHandler -Chord 'Ctrl+Backspace' -ScriptBlock {
 
 Set-PSReadLineKeyHandler -Chord 'Tab' -ScriptBlock {
     param($key, $arg)
-    if ($script:_nh_suggestion) {
+    if ($script:_nh_state.suggestion) {
         _nh_accept
     } else {
         [Microsoft.PowerShell.PSConsoleReadLine]::TabCompleteNext($key, $arg)
@@ -297,7 +334,7 @@ Set-PSReadLineKeyHandler -Chord 'RightArrow' -ScriptBlock {
     param($key, $arg)
     $line = ''; $cursor = 0
     [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$line, [ref]$cursor)
-    if ($script:_nh_suggestion -and $cursor -eq $line.Length) {
+    if ($script:_nh_state.suggestion -and $cursor -eq $line.Length) {
         _nh_accept
     } else {
         [Microsoft.PowerShell.PSConsoleReadLine]::ForwardChar($key, $arg)
@@ -312,9 +349,11 @@ Set-PSReadLineKeyHandler -Chord 'Enter' -ScriptBlock {
 
 Set-PSReadLineKeyHandler -Chord 'Escape' -ScriptBlock {
     param($key, $arg)
-    if ($script:_nh_ghost_len -gt 0) {
+    if ($script:_nh_state.ghost_len -gt 0) {
         _nh_clear_ghost
     } else {
         [Microsoft.PowerShell.PSConsoleReadLine]::RevertLine($key, $arg)
     }
 }
+
+_nh_log "plugin loaded (debounce_ms=$($script:_nh_debounce_ms), debug=$($script:_nh_debug))"

--- a/shells/nighthawk.ps1
+++ b/shells/nighthawk.ps1
@@ -9,7 +9,37 @@ $script:_nh_esc = [char]27
 try { Set-PSReadLineOption -PredictionSource None } catch {}
 
 # --- Configuration ---
-$script:_nh_hint_arrow = if ($env:NIGHTHAWK_HINT_ARROW) { $env:NIGHTHAWK_HINT_ARROW } else { '->' }
+# Load plugin settings from config.toml [plugin] section (simple regex parse).
+# Env vars override config file values.
+function _nh_load_plugin_config {
+    $settings = @{
+        timeout_ms = 100
+        hint_arrow = '->'
+    }
+    $configPath = Join-Path $env:APPDATA "nighthawk\config.toml"
+    if (Test-Path $configPath) {
+        try {
+            $content = Get-Content $configPath -Raw -ErrorAction Stop
+            # Extract [plugin] section only (until next section or EOF)
+            if ($content -match '(?ms)^\[plugin\]\s*(.*?)(?=^\[|\z)') {
+                $section = $matches[1]
+                if ($section -match '(?m)^\s*timeout_ms\s*=\s*(\d+)') {
+                    $settings.timeout_ms = [int]$matches[1]
+                }
+                if ($section -match '(?m)^\s*hint_arrow\s*=\s*"([^"]*)"') {
+                    $settings.hint_arrow = $matches[1]
+                }
+            }
+        } catch {
+            # Silently ignore config read errors — use defaults
+        }
+    }
+    return $settings
+}
+
+$script:_nh_config = _nh_load_plugin_config
+$script:_nh_hint_arrow = if ($env:NIGHTHAWK_HINT_ARROW) { $env:NIGHTHAWK_HINT_ARROW } else { $script:_nh_config.hint_arrow }
+$script:_nh_timeout_ms = if ($env:NIGHTHAWK_TIMEOUT_MS) { [int]$env:NIGHTHAWK_TIMEOUT_MS } else { $script:_nh_config.timeout_ms }
 
 # --- State ---
 $script:_nh_pipe = 'nighthawk'
@@ -20,6 +50,17 @@ $script:_nh_ghost_len = 0
 $script:_nh_last_buffer = ''
 $script:_nh_tried_start = $false
 $script:_nh_backoff_until = [DateTime]::MinValue
+
+# Async pending query state (for cloud-tier slow responses)
+$script:_nh_pending_pipe = $null
+$script:_nh_pending_task = $null
+$script:_nh_pending_buffer = ''
+$script:_nh_pending_cursor = 0
+$script:_nh_last_query_at = [DateTime]::MinValue
+# Minimum ms between queries (throttle to prevent hammering daemon while typing)
+$script:_nh_throttle_ms = 150
+# How long to wait synchronously for response (fast tiers respond quickly)
+$script:_nh_quick_wait_ms = [Math]::Min($script:_nh_timeout_ms, 150)
 
 # --- Ghost text rendering via ANSI ---
 function _nh_render_ghost([string]$ghost) {
@@ -59,8 +100,69 @@ function _nh_ensure_daemon {
     }
 }
 
+# --- Render a response (shared between sync and async paths) ---
+function _nh_render_response {
+    param([string]$response, [string]$line, [int]$cursor)
+    if (-not $response) { return }
+    try {
+        $parsed = $response | ConvertFrom-Json
+    } catch { return }
+    if (-not $parsed.suggestions -or $parsed.suggestions.Count -eq 0) { return }
+
+    $s = $parsed.suggestions[0]
+    $script:_nh_suggestion = $s.text
+    $script:_nh_replace_start = [int]$s.replace_start
+    $script:_nh_replace_end = [int]$s.replace_end
+
+    if ($s.PSObject.Properties['diff_ops'] -and $null -ne $s.diff_ops) {
+        _nh_render_ghost " $($script:_nh_hint_arrow) $($s.text)"
+    } else {
+        $typed_len = $cursor - $script:_nh_replace_start
+        if ($typed_len -ge 0 -and $typed_len -lt $s.text.Length) {
+            $typed_part = $line.Substring($script:_nh_replace_start, $typed_len)
+            if ($s.text.StartsWith($typed_part, [System.StringComparison]::Ordinal)) {
+                _nh_render_ghost $s.text.Substring($typed_len)
+            } else {
+                _nh_render_ghost " $($script:_nh_hint_arrow) $($s.text)"
+            }
+        }
+    }
+}
+
+# --- Check if a previous async query completed ---
+function _nh_check_pending {
+    if (-not $script:_nh_pending_task) { return }
+    if (-not $script:_nh_pending_task.IsCompleted) { return }
+
+    try {
+        $response = $script:_nh_pending_task.Result
+
+        # Get current buffer - only render if it still matches what we queried for
+        $cur_line = ''; $cur_cursor = 0
+        [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$cur_line, [ref]$cur_cursor)
+        if ($cur_line -eq $script:_nh_pending_buffer -and $cur_cursor -eq $cur_line.Length) {
+            _nh_render_response $response $cur_line $cur_cursor
+        }
+    } catch {}
+
+    _nh_cleanup_pending
+}
+
+function _nh_cleanup_pending {
+    if ($script:_nh_pending_pipe) {
+        try { $script:_nh_pending_pipe.Dispose() } catch {}
+    }
+    $script:_nh_pending_pipe = $null
+    $script:_nh_pending_task = $null
+    $script:_nh_pending_buffer = ''
+    $script:_nh_pending_cursor = 0
+}
+
 # --- Daemon communication ---
 function _nh_query {
+    # First: check if a previous async query completed (may render ghost text)
+    _nh_check_pending
+
     $line = ''; $cursor = 0
     [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$line, [ref]$cursor)
 
@@ -68,11 +170,14 @@ function _nh_query {
     if ($cursor -ne $line.Length -or $line.Length -lt 2) { return }
     if ($line -eq $script:_nh_last_buffer) { return }
 
+    # Throttle: skip if we queried too recently (prevents hammering daemon while typing)
+    $elapsed = ([DateTime]::UtcNow - $script:_nh_last_query_at).TotalMilliseconds
+    if ($elapsed -lt $script:_nh_throttle_ms) { return }
+
     # Backoff: skip queries for 5s after connection failure
     if ([DateTime]::UtcNow -lt $script:_nh_backoff_until) { return }
 
     # Fast check: bail if the named pipe doesn't exist.
-    # Connect() on .NET Framework sleeps ~50ms internally even for non-existent pipes.
     if (-not (Test-Path "\\.\pipe\$($script:_nh_pipe)")) {
         $script:_nh_backoff_until = [DateTime]::UtcNow.AddSeconds(5)
         if (-not $script:_nh_tried_start) { _nh_ensure_daemon }
@@ -80,6 +185,10 @@ function _nh_query {
     }
 
     $script:_nh_last_buffer = $line
+    $script:_nh_last_query_at = [DateTime]::UtcNow
+
+    # Cancel any in-progress query (user typed again, previous is stale)
+    _nh_cleanup_pending
 
     try {
         # Escape for JSON (critical for Windows paths: C:\Users → C:\\Users)
@@ -88,56 +197,33 @@ function _nh_query {
         $json = "{`"input`":`"$esc_input`",`"cursor`":$cursor,`"cwd`":`"$esc_cwd`",`"shell`":`"powershell`"}"
 
         $pipe = [System.IO.Pipes.NamedPipeClientStream]::new('.', $script:_nh_pipe, [System.IO.Pipes.PipeDirection]::InOut)
-        try {
-            $pipe.Connect(20)
+        $pipe.Connect(20)
 
-            $utf8 = [System.Text.UTF8Encoding]::new($false)  # UTF-8 without BOM
-            $writer = [System.IO.StreamWriter]::new($pipe, $utf8)
-            $writer.AutoFlush = $true
-            $writer.WriteLine($json)
+        $utf8 = [System.Text.UTF8Encoding]::new($false)
+        $writer = [System.IO.StreamWriter]::new($pipe, $utf8)
+        $writer.AutoFlush = $true
+        $writer.WriteLine($json)
 
-            $reader = [System.IO.StreamReader]::new($pipe, $utf8)
-            $readTask = $reader.ReadLineAsync()
-            if (-not $readTask.Wait(100)) {
-                # Read timed out — daemon connected but not responding (likely shutting down).
-                # Back off so every keystroke doesn't pay ~100ms.
-                $script:_nh_backoff_until = [DateTime]::UtcNow.AddSeconds(5)
-                return
-            }
+        $reader = [System.IO.StreamReader]::new($pipe, $utf8)
+        $readTask = $reader.ReadLineAsync()
+
+        # Quick sync wait - fast tiers (history, specs) respond in <50ms
+        if ($readTask.Wait($script:_nh_quick_wait_ms)) {
+            # Fast response - render immediately
             $response = $readTask.Result
-        } finally {
             $pipe.Dispose()
-        }
-
-        if (-not $response) { return }
-        $parsed = $response | ConvertFrom-Json
-        if (-not $parsed.suggestions -or $parsed.suggestions.Count -eq 0) { return }
-
-        $s = $parsed.suggestions[0]
-        $script:_nh_suggestion = $s.text
-        $script:_nh_replace_start = [int]$s.replace_start
-        $script:_nh_replace_end = [int]$s.replace_end
-
-        if ($s.PSObject.Properties['diff_ops'] -and $null -ne $s.diff_ops) {
-            # Fuzzy match: render as hint " → suggestion"
-            _nh_render_ghost " $($script:_nh_hint_arrow) $($s.text)"
+            _nh_render_response $response $line $cursor
         } else {
-            $typed_len = $cursor - $script:_nh_replace_start
-            if ($typed_len -ge 0 -and $typed_len -lt $s.text.Length) {
-                $typed_part = $line.Substring($script:_nh_replace_start, $typed_len)
-                if ($s.text.StartsWith($typed_part, [System.StringComparison]::Ordinal)) {
-                    # True prefix match: show suffix as ghost text
-                    _nh_render_ghost $s.text.Substring($typed_len)
-                } else {
-                    # Replacement changes typed text: show hint instead
-                    _nh_render_ghost " $($script:_nh_hint_arrow) $($s.text)"
-                }
-            }
+            # Slow response (cloud tier) - store task, check on next keystroke
+            $script:_nh_pending_pipe = $pipe
+            $script:_nh_pending_task = $readTask
+            $script:_nh_pending_buffer = $line
+            $script:_nh_pending_cursor = $cursor
         }
     }
     catch {
-        # Back off for 5s so failed connections don't block typing
         $script:_nh_backoff_until = [DateTime]::UtcNow.AddSeconds(5)
+        _nh_cleanup_pending
     }
 }
 

--- a/shells/nighthawk.ps1
+++ b/shells/nighthawk.ps1
@@ -58,17 +58,20 @@ function _nh_log {
 # `published` is a hashtable reference — assignment is a single pointer write, never torn —
 # so foreground readers can snapshot once and use snap['text']/['start']/['end'] safely.
 $script:_nh_state = [hashtable]::Synchronized(@{
-    pipe_name      = 'nighthawk'
-    hint_arrow     = $script:_nh_hint_arrow
-    debug          = $script:_nh_debug
-    log_path       = $script:_nh_log_path
-    esc            = [char]27
-    pending_buffer = ''
-    pending_cursor = 0
-    pending_cwd    = ''
-    generation     = 0
-    published      = $null   # @{ text=...; start=...; end=... } or $null
-    ghost_len      = 0
+    pipe_name       = 'nighthawk'
+    hint_arrow      = $script:_nh_hint_arrow
+    debug           = $script:_nh_debug
+    log_path        = $script:_nh_log_path
+    esc             = [char]27
+    utf8            = [System.Text.UTF8Encoding]::new($false)
+    read_timeout_ms = 2250
+    pending_buffer  = ''
+    pending_cursor  = 0
+    pending_cwd     = ''
+    generation      = 0
+    published       = $null   # @{ text=...; start=...; end=... } or $null
+    ghost_len       = 0
+    inflight        = [System.Collections.Generic.List[object]]::new()
 })
 
 # --- Ghost text clear ---
@@ -148,11 +151,6 @@ $script:_nh_worker = {
 
         if (-not $line -or $line.Length -lt 2) { return }
 
-        if (-not (Test-Path "\\.\pipe\$($state.pipe_name)")) {
-            & $writeLog "skip: pipe missing"
-            return
-        }
-
         $esc_input = & $jsonEscape $line
         $esc_cwd = & $jsonEscape $cwd
         $json = '{"input":"' + $esc_input + '","cursor":' + $cursor + ',"cwd":"' + $esc_cwd + '","shell":"powershell"}'
@@ -166,7 +164,7 @@ $script:_nh_worker = {
         $response = $null
         try {
             $pipe.Connect(50)
-            $utf8 = [System.Text.UTF8Encoding]::new($false)
+            $utf8 = $state.utf8
             $writer = [System.IO.StreamWriter]::new($pipe, $utf8)
             $writer.AutoFlush = $true
             $writer.WriteLine($json)
@@ -174,10 +172,10 @@ $script:_nh_worker = {
 
             # Bounded async read — if daemon hangs we don't hang the worker forever.
             $task = $reader.ReadLineAsync()
-            if ($task.Wait(2250)) {
+            if ($task.Wait($state.read_timeout_ms)) {
                 $response = $task.Result
             } else {
-                & $writeLog "read timeout 2250ms"
+                & $writeLog "read timeout $($state.read_timeout_ms)ms"
                 # Observe the orphan task to suppress post-dispose UnobservedTaskException.
                 $null = $task.ContinueWith(
                     { param($t) $null = $t.Exception },
@@ -222,7 +220,7 @@ $script:_nh_worker = {
             $ghost = " $($state.hint_arrow) $text"
         } else {
             $typed_len = $cursor - $rstart
-            if ($typed_len -ge 0 -and $typed_len -lt $text.Length) {
+            if ($typed_len -ge 0 -and $typed_len -lt $text.Length -and ($rstart + $typed_len) -le $line.Length) {
                 $typed_part = $line.Substring($rstart, $typed_len)
                 if ($text.StartsWith($typed_part, [System.StringComparison]::Ordinal)) {
                     $ghost = $text.Substring($typed_len)
@@ -253,6 +251,8 @@ $script:_nh_worker = {
 }
 
 # --- Re-source cleanup: tear down prior subscriber, timer, pool before recreating ---
+# Order matters: unregister the subscriber first (so a late Elapsed can't dispatch into
+# a closing pool), then stop+dispose the timer, then close+dispose the pool.
 Get-EventSubscriber -SourceIdentifier 'nh_debounce' -ErrorAction SilentlyContinue | Unregister-Event -ErrorAction SilentlyContinue
 if ($script:_nh_timer) {
     try { $script:_nh_timer.Stop(); $script:_nh_timer.Dispose() } catch {}
@@ -279,30 +279,36 @@ $script:_nh_timer.Interval = $script:_nh_debounce_ms
 # so we'd otherwise pay a ToString() per keystroke.
 $script:_nh_worker_text = $script:_nh_worker.ToString()
 
-# Bundle for the Action runspace (can't see $script: vars).
-$script:_nh_event_data = @{
-    state       = $script:_nh_state
-    worker_text = $script:_nh_worker_text
-    pool        = $script:_nh_runspacepool
-}
-
 $null = Register-ObjectEvent -InputObject $script:_nh_timer -EventName Elapsed `
-    -SourceIdentifier 'nh_debounce' -MessageData $script:_nh_event_data -Action {
+    -SourceIdentifier 'nh_debounce' -MessageData @{
+        state       = $script:_nh_state
+        worker_text = $script:_nh_worker_text
+        pool        = $script:_nh_runspacepool
+    } -Action {
     $data = $Event.MessageData
     $state = $data.state
 
     try {
-        if (-not (Test-Path "\\.\pipe\$($state.pipe_name)")) { return }
+        # Prune completed instances. EndInvoke on a completed IAsyncResult releases its
+        # kernel ManualResetEvent; Dispose releases the PowerShell instance. Skip
+        # incomplete slots so this stays O(pool size) and never blocks.
+        $inflight = $state.inflight
+        for ($i = $inflight.Count - 1; $i -ge 0; $i--) {
+            if ($inflight[$i].iar.IsCompleted) {
+                $slot = $inflight[$i]
+                try { $null = $slot.ps.EndInvoke($slot.iar) } catch {}
+                try { $slot.ps.Dispose() } catch {}
+                $inflight.RemoveAt($i)
+            }
+        }
 
         # Dispatch to a pooled runspace. BeginInvoke returns immediately — the event-handler
         # runspace (pumped on the main pipeline thread) is freed before the IPC happens.
         $ps = [PowerShell]::Create()
         $ps.RunspacePool = $data.pool
         $null = $ps.AddScript($data.worker_text).AddArgument($state)
-        $null = $ps.BeginInvoke()
-        # Note: $ps + IAsyncResult are not explicitly disposed. GC reclaims them once the
-        # runspace returns to the pool. Per-call leak is small (~few KB); over a typical
-        # shell session this is bounded and acceptable.
+        $iar = $ps.BeginInvoke()
+        $inflight.Add(@{ ps = $ps; iar = $iar })
     } catch {
         if ($state.debug) {
             try {
@@ -353,6 +359,11 @@ function _nh_accept {
         $text = [string]$snap['text']
         $start = [int]$snap['start']
         $end = [int]$snap['end']
+        # Buffer may have shrunk since the worker captured the suggestion; re-read it so
+        # PSReadLine.Replace doesn't throw ArgumentOutOfRangeException on a stale end.
+        $current = ''; $cur = 0
+        [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$current, [ref]$cur)
+        if ($end -gt $current.Length) { return }
         _nh_clear_ghost
         $len = $end - $start
         [Microsoft.PowerShell.PSConsoleReadLine]::Replace($start, $len, $text)

--- a/shells/nighthawk.ps1
+++ b/shells/nighthawk.ps1
@@ -9,8 +9,6 @@ $script:_nh_esc = [char]27
 try { Set-PSReadLineOption -PredictionSource None } catch {}
 
 # --- Configuration ---
-# Load plugin settings from config.toml [plugin] section (simple regex parse).
-# Env vars override config file values.
 function _nh_load_plugin_config {
     $settings = @{
         debounce_ms = 200
@@ -44,8 +42,7 @@ $script:_nh_debounce_ms = if ($env:NIGHTHAWK_DEBOUNCE_MS) { [int]$env:NIGHTHAWK_
 $script:_nh_debug = if ($env:NIGHTHAWK_DEBUG) { $env:NIGHTHAWK_DEBUG -eq '1' } else { $script:_nh_config.debug }
 $script:_nh_log_path = Join-Path $env:APPDATA "nighthawk\plugin.log"
 
-# --- Diagnostic logging (only when debug enabled) ---
-# Thread-safe via append; can be called from foreground or background.
+# --- Diagnostic logging (foreground) ---
 function _nh_log {
     param([string]$msg)
     if (-not $script:_nh_debug) { return }
@@ -56,46 +53,34 @@ function _nh_log {
     } catch {}
 }
 
-# --- Synchronized shared state (accessed across threads) ---
-# Foreground reads/writes via $script:_nh_state.X
-# Background timer Action reads/writes via $Event.MessageData.X (same hashtable instance)
+# --- Synchronized shared state ---
+# Foreground writes pending_* fields; runspace-pool worker reads pending_* and writes `published`.
+# `published` is a hashtable reference — assignment is a single pointer write, never torn —
+# so foreground readers can snapshot once and use snap['text']/['start']/['end'] safely.
 $script:_nh_state = [hashtable]::Synchronized(@{
     pipe_name      = 'nighthawk'
-    debounce_ms    = $script:_nh_debounce_ms
     hint_arrow     = $script:_nh_hint_arrow
     debug          = $script:_nh_debug
     log_path       = $script:_nh_log_path
     esc            = [char]27
-    # Per-keystroke captured state
     pending_buffer = ''
     pending_cursor = 0
+    pending_cwd    = ''
     generation     = 0
-    # Currently-displayed ghost suggestion (read by accept handler)
-    suggestion     = ''
-    replace_start  = -1
-    replace_end    = -1
+    published      = $null   # @{ text=...; start=...; end=... } or $null
     ghost_len      = 0
 })
 
-# --- Ghost text rendering via ANSI ---
-# Uses [Console]::Write so it's safe to call from any thread.
-function _nh_render_ghost([string]$ghost) {
-    if ($ghost.Length -eq 0) { return }
-    $e = $script:_nh_esc
-    $clean = $ghost -replace '"', ''
-    $script:_nh_state.ghost_len = $clean.Length
-    [System.Console]::Write("${e}[s${e}[90m${clean}${e}[0m${e}[u")
-}
-
+# --- Ghost text clear ---
+# Bumps generation unconditionally so any in-flight worker sees its result as stale.
 function _nh_clear_ghost {
+    $script:_nh_state.generation++
     if ($script:_nh_state.ghost_len -gt 0) {
         $e = $script:_nh_esc
         [System.Console]::Write("${e}[s${e}[0J${e}[u")
         $script:_nh_state.ghost_len = 0
     }
-    $script:_nh_state.suggestion = ''
-    $script:_nh_state.replace_start = -1
-    $script:_nh_state.replace_end = -1
+    $script:_nh_state.published = $null
 }
 
 # --- Auto-start ---
@@ -110,61 +95,74 @@ function _nh_ensure_daemon {
     }
 }
 
-# --- Debounce timer + ROE event subscriber ---
-# Register-ObjectEvent runs the -Action in PowerShell's event-handler runspace.
-# That runspace cannot see this script's functions or $script: vars, so:
-#   - State is shared via -MessageData (synchronized hashtable, by reference)
-#   - Daemon IPC + render logic is INLINED in the Action block
-#   - All ANSI output goes through [Console]::Write (thread-safe)
-$script:_nh_timer = [System.Timers.Timer]::new()
-$script:_nh_timer.AutoReset = $false
-$script:_nh_timer.Interval = $script:_nh_debounce_ms
+# --- Background worker scriptblock ---
+# Runs on a RunspacePool worker (invoked via [PowerShell]::Create().BeginInvoke()).
+# Receives only the synchronized $state hashtable — no other foreground vars are visible.
+# All output goes through [Console]::Write and a single atomic $state.published assignment.
+$script:_nh_worker = {
+    param([hashtable]$state)
 
-# Cleanup any previous registration if plugin is re-sourced
-Get-EventSubscriber -SourceIdentifier 'nh_debounce' -ErrorAction SilentlyContinue | Unregister-Event -ErrorAction SilentlyContinue
+    # JSON escape: \\, \", \b, \f, \n, \r, \t, plus \uXXXX for any other 0x00-0x1F control chars.
+    $jsonEscape = {
+        param([string]$s)
+        if ([string]::IsNullOrEmpty($s)) { return '' }
+        $sb = [System.Text.StringBuilder]::new($s.Length + 8)
+        foreach ($ch in $s.ToCharArray()) {
+            $code = [int]$ch
+            switch ($ch) {
+                '\'  { [void]$sb.Append('\\') }
+                '"'  { [void]$sb.Append('\"') }
+                "`b" { [void]$sb.Append('\b') }
+                "`f" { [void]$sb.Append('\f') }
+                "`n" { [void]$sb.Append('\n') }
+                "`r" { [void]$sb.Append('\r') }
+                "`t" { [void]$sb.Append('\t') }
+                default {
+                    if ($code -lt 0x20) {
+                        [void]$sb.AppendFormat('\u{0:x4}', $code)
+                    } else {
+                        [void]$sb.Append($ch)
+                    }
+                }
+            }
+        }
+        return $sb.ToString()
+    }
 
-$null = Register-ObjectEvent -InputObject $script:_nh_timer -EventName Elapsed `
-    -SourceIdentifier 'nh_debounce' -MessageData $script:_nh_state -Action {
-    $state = $Event.MessageData
-
-    # Inline diagnostic log (can't call _nh_log from this runspace)
+    # Worker-side log. $force=$true bypasses debug-gate so fatal exceptions always leave a trace.
     $writeLog = {
-        param([string]$m)
-        if (-not $state.debug) { return }
+        param([string]$m, [bool]$force = $false)
+        if (-not $force -and -not $state.debug) { return }
         try {
             $ts = (Get-Date).ToString('HH:mm:ss.fff')
             $tid = [System.Threading.Thread]::CurrentThread.ManagedThreadId
-            Add-Content -Path $state.log_path -Value "$ts t$tid [bg] $m" -ErrorAction SilentlyContinue
+            [System.IO.File]::AppendAllText($state.log_path, "$ts t$tid [bg] $m`r`n")
         } catch {}
     }
-
-    & $writeLog "Elapsed fired (gen=$($state.generation), buf='$($state.pending_buffer)')"
 
     try {
         $myGen = $state.generation
         $line = $state.pending_buffer
         $cursor = $state.pending_cursor
+        $cwd = $state.pending_cwd
 
-        if (-not $line -or $line.Length -lt 2) {
-            & $writeLog "skip: empty/short buffer"
+        if (-not $line -or $line.Length -lt 2) { return }
+
+        if (-not (Test-Path "\\.\pipe\$($state.pipe_name)")) {
+            & $writeLog "skip: pipe missing"
             return
         }
 
-        $pipePath = "\\.\pipe\$($state.pipe_name)"
-        if (-not (Test-Path $pipePath)) {
-            & $writeLog "skip: pipe missing at $pipePath"
-            return
-        }
-
-        # Build JSON request (escape Windows backslashes, quotes, newlines)
-        $esc_input = $line -replace '\\','\\' -replace '"','\"' -replace "`n",'\n' -replace "`r",'\r'
-        $esc_cwd = $PWD.Path -replace '\\','\\' -replace '"','\"'
-        $json = "{`"input`":`"$esc_input`",`"cursor`":$cursor,`"cwd`":`"$esc_cwd`",`"shell`":`"powershell`"}"
+        $esc_input = & $jsonEscape $line
+        $esc_cwd = & $jsonEscape $cwd
+        $json = '{"input":"' + $esc_input + '","cursor":' + $cursor + ',"cwd":"' + $esc_cwd + '","shell":"powershell"}'
 
         & $writeLog "sending request len=$($line.Length)"
 
-        # Synchronous IPC — daemon enforces tier budgets so this is bounded
+        # Synchronous IPC bounded by daemon's tier budget (cloud=2000ms) + 250ms slack.
         $pipe = [System.IO.Pipes.NamedPipeClientStream]::new('.', $state.pipe_name, [System.IO.Pipes.PipeDirection]::InOut)
+        $reader = $null
+        $writer = $null
         $response = $null
         try {
             $pipe.Connect(50)
@@ -173,68 +171,145 @@ $null = Register-ObjectEvent -InputObject $script:_nh_timer -EventName Elapsed `
             $writer.AutoFlush = $true
             $writer.WriteLine($json)
             $reader = [System.IO.StreamReader]::new($pipe, $utf8)
-            $response = $reader.ReadLine()
+
+            # Bounded async read — if daemon hangs we don't hang the worker forever.
+            $task = $reader.ReadLineAsync()
+            if ($task.Wait(2250)) {
+                $response = $task.Result
+            } else {
+                & $writeLog "read timeout 2250ms"
+                # Observe the orphan task to suppress post-dispose UnobservedTaskException.
+                $null = $task.ContinueWith(
+                    { param($t) $null = $t.Exception },
+                    [System.Threading.Tasks.TaskContinuationOptions]::OnlyOnFaulted)
+                return
+            }
         } finally {
-            $pipe.Dispose()
+            if ($reader) { try { $reader.Dispose() } catch {} }
+            if ($writer) { try { $writer.Dispose() } catch {} }
+            try { $pipe.Dispose() } catch {}
         }
 
-        if (-not $response) {
-            & $writeLog "empty response"
-            return
-        }
-
-        # Staleness check — abort if user typed during the daemon call
+        if (-not $response) { return }
         if ($state.generation -ne $myGen) {
-            & $writeLog "stale (gen advanced $myGen -> $($state.generation))"
+            & $writeLog "stale (gen advanced)"
             return
         }
 
-        # Parse response
+        # Parse with ConvertFrom-Json (works on PS 5.1 + PS 7+). Returns PSCustomObjects.
         $parsed = $null
-        try { $parsed = $response | ConvertFrom-Json } catch {
+        try {
+            $parsed = $response | ConvertFrom-Json -ErrorAction Stop
+        } catch {
             & $writeLog "parse fail: $($_.Exception.Message)"
             return
         }
-        if (-not $parsed.suggestions -or $parsed.suggestions.Count -eq 0) {
-            & $writeLog "no suggestions"
+
+        if (-not $parsed -or -not $parsed.suggestions -or $parsed.suggestions.Count -eq 0) { return }
+
+        $s = $parsed.suggestions[0]
+        if (-not $s.text -or $null -eq $s.replace_start -or $null -eq $s.replace_end) {
+            & $writeLog "malformed suggestion"
             return
         }
 
-        $s = $parsed.suggestions[0]
-        $state.suggestion = $s.text
-        $state.replace_start = [int]$s.replace_start
-        $state.replace_end = [int]$s.replace_end
+        $text = [string]$s.text
+        $rstart = [int]$s.replace_start
+        $rend = [int]$s.replace_end
 
-        # Compute ghost text
         $ghost = $null
         if ($s.PSObject.Properties['diff_ops'] -and $null -ne $s.diff_ops) {
-            $ghost = " $($state.hint_arrow) $($s.text)"
+            $ghost = " $($state.hint_arrow) $text"
         } else {
-            $typed_len = $cursor - [int]$s.replace_start
-            if ($typed_len -ge 0 -and $typed_len -lt $s.text.Length) {
-                $typed_part = $line.Substring([int]$s.replace_start, $typed_len)
-                if ($s.text.StartsWith($typed_part, [System.StringComparison]::Ordinal)) {
-                    $ghost = $s.text.Substring($typed_len)
+            $typed_len = $cursor - $rstart
+            if ($typed_len -ge 0 -and $typed_len -lt $text.Length) {
+                $typed_part = $line.Substring($rstart, $typed_len)
+                if ($text.StartsWith($typed_part, [System.StringComparison]::Ordinal)) {
+                    $ghost = $text.Substring($typed_len)
                 } else {
-                    $ghost = " $($state.hint_arrow) $($s.text)"
+                    $ghost = " $($state.hint_arrow) $text"
                 }
             }
         }
 
-        if (-not $ghost) {
-            & $writeLog "no ghost computed"
-            return
-        }
+        if (-not $ghost) { return }
 
-        $clean = $ghost -replace '"', ''
-        $state.ghost_len = $clean.Length
+        # Final staleness check before publishing — user may have typed during parse.
+        if ($state.generation -ne $myGen) { return }
 
-        # Render via [Console]::Write — thread-safe, bypasses runspace $Host
+        $state.ghost_len = $ghost.Length
         $e = $state.esc
-        [System.Console]::Write("${e}[s${e}[90m${clean}${e}[0m${e}[u")
-        & $writeLog "rendered ghost (len=$($clean.Length))"
+        [System.Console]::Write("${e}[s${e}[90m${ghost}${e}[0m${e}[u")
+        $state.published = @{
+            text  = $text
+            start = $rstart
+            end   = $rend
+        }
+        & $writeLog "rendered ghost (len=$($ghost.Length))"
     } catch {
-        & $writeLog "EXCEPTION: $($_.Exception.Message)"
+        # Unconditional — fatal worker exceptions always log, even with debug=false.
+        & $writeLog "bg-FATAL: $($_.Exception.GetType().FullName): $($_.Exception.Message)" $true
+    }
+}
+
+# --- Re-source cleanup: tear down prior subscriber, timer, pool before recreating ---
+Get-EventSubscriber -SourceIdentifier 'nh_debounce' -ErrorAction SilentlyContinue | Unregister-Event -ErrorAction SilentlyContinue
+if ($script:_nh_timer) {
+    try { $script:_nh_timer.Stop(); $script:_nh_timer.Dispose() } catch {}
+}
+if ($script:_nh_runspacepool) {
+    try { $script:_nh_runspacepool.Close(); $script:_nh_runspacepool.Dispose() } catch {}
+}
+
+# --- Runspace pool for background IPC workers ---
+# Pool size (1, 3): one worker covers the steady-state debounce; up to 3 lets overlapping
+# bursts run concurrently without blocking the event-handler runspace.
+# CRITICAL: workers MUST run on a RunspacePool, not a raw [System.Threading.Thread]. PowerShell
+# scriptblocks need a Runspace in TLS to execute; without one, ScriptBlock.GetContextFromTLS()
+# throws and the unhandled exception fast-fails the entire pwsh process (CLR 0xE0434352).
+$script:_nh_runspacepool = [runspacefactory]::CreateRunspacePool(1, 3)
+$script:_nh_runspacepool.Open()
+
+# --- Debounce timer + ROE event subscriber ---
+$script:_nh_timer = [System.Timers.Timer]::new()
+$script:_nh_timer.AutoReset = $false
+$script:_nh_timer.Interval = $script:_nh_debounce_ms
+
+# Pre-serialize the worker scriptblock body — [PowerShell]::AddScript takes a string,
+# so we'd otherwise pay a ToString() per keystroke.
+$script:_nh_worker_text = $script:_nh_worker.ToString()
+
+# Bundle for the Action runspace (can't see $script: vars).
+$script:_nh_event_data = @{
+    state       = $script:_nh_state
+    worker_text = $script:_nh_worker_text
+    pool        = $script:_nh_runspacepool
+}
+
+$null = Register-ObjectEvent -InputObject $script:_nh_timer -EventName Elapsed `
+    -SourceIdentifier 'nh_debounce' -MessageData $script:_nh_event_data -Action {
+    $data = $Event.MessageData
+    $state = $data.state
+
+    try {
+        if (-not (Test-Path "\\.\pipe\$($state.pipe_name)")) { return }
+
+        # Dispatch to a pooled runspace. BeginInvoke returns immediately — the event-handler
+        # runspace (pumped on the main pipeline thread) is freed before the IPC happens.
+        $ps = [PowerShell]::Create()
+        $ps.RunspacePool = $data.pool
+        $null = $ps.AddScript($data.worker_text).AddArgument($state)
+        $null = $ps.BeginInvoke()
+        # Note: $ps + IAsyncResult are not explicitly disposed. GC reclaims them once the
+        # runspace returns to the pool. Per-call leak is small (~few KB); over a typical
+        # shell session this is bounded and acceptable.
+    } catch {
+        if ($state.debug) {
+            try {
+                $ts = (Get-Date).ToString('HH:mm:ss.fff')
+                Add-Content -Path $state.log_path -Value "$ts [evt] dispatch fail: $($_.Exception.Message)" -ErrorAction SilentlyContinue
+            } catch {}
+        }
     }
 }
 
@@ -247,10 +322,7 @@ function _nh_query {
 
     if ($cursor -ne $line.Length -or $line.Length -lt 2) { return }
 
-    if ([DateTime]::UtcNow -lt $script:_nh_backoff_until) {
-        _nh_log "_nh_query: in backoff window"
-        return
-    }
+    if ([DateTime]::UtcNow -lt $script:_nh_backoff_until) { return }
 
     if (-not (Test-Path "\\.\pipe\$($script:_nh_state.pipe_name)")) {
         _nh_log "_nh_query: pipe missing, setting backoff"
@@ -259,12 +331,13 @@ function _nh_query {
         return
     }
 
-    # Capture state for the timer Elapsed callback
+    # Capture state for the worker. $PWD must be captured here in the foreground runspace —
+    # workers don't have the user's current directory.
     $script:_nh_state.pending_buffer = $line
     $script:_nh_state.pending_cursor = $cursor
+    $script:_nh_state.pending_cwd = $PWD.Path
     $script:_nh_state.generation++
 
-    # Reset debounce window
     $script:_nh_timer.Stop()
     $script:_nh_timer.Start()
 
@@ -272,11 +345,14 @@ function _nh_query {
 }
 
 # --- Accept suggestion ---
+# Snapshots $state.published once so a worker publishing mid-accept can't tear our read.
 function _nh_accept {
-    if ($script:_nh_state.suggestion -and $script:_nh_state.replace_start -ge 0) {
-        $text = $script:_nh_state.suggestion
-        $start = $script:_nh_state.replace_start
-        $end = $script:_nh_state.replace_end
+    $script:_nh_state.generation++
+    $snap = $script:_nh_state.published
+    if ($snap -and [int]$snap['start'] -ge 0) {
+        $text = [string]$snap['text']
+        $start = [int]$snap['start']
+        $end = [int]$snap['end']
         _nh_clear_ghost
         $len = $end - $start
         [Microsoft.PowerShell.PSConsoleReadLine]::Replace($start, $len, $text)
@@ -323,7 +399,7 @@ Set-PSReadLineKeyHandler -Chord 'Ctrl+Backspace' -ScriptBlock {
 
 Set-PSReadLineKeyHandler -Chord 'Tab' -ScriptBlock {
     param($key, $arg)
-    if ($script:_nh_state.suggestion) {
+    if ($script:_nh_state.published) {
         _nh_accept
     } else {
         [Microsoft.PowerShell.PSConsoleReadLine]::TabCompleteNext($key, $arg)
@@ -334,7 +410,7 @@ Set-PSReadLineKeyHandler -Chord 'RightArrow' -ScriptBlock {
     param($key, $arg)
     $line = ''; $cursor = 0
     [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$line, [ref]$cursor)
-    if ($script:_nh_state.suggestion -and $cursor -eq $line.Length) {
+    if ($script:_nh_state.published -and $cursor -eq $line.Length) {
         _nh_accept
     } else {
         [Microsoft.PowerShell.PSConsoleReadLine]::ForwardChar($key, $arg)

--- a/shells/nighthawk.ps1
+++ b/shells/nighthawk.ps1
@@ -75,8 +75,13 @@ $script:_nh_state = [hashtable]::Synchronized(@{
 })
 
 # --- Ghost text clear ---
-# Bumps generation unconditionally so any in-flight worker sees its result as stale.
+# Bumps generation so any in-flight worker sees its result as stale, AND stops the
+# debounce timer so a pending dispatch (scheduled before the user moved on) doesn't
+# fire with stale pending_buffer/cursor and render a phantom ghost. The next _nh_query
+# call (from the very next keystroke) will Start() the timer again — this only kills
+# dispatches the user has invalidated by typing/Enter/Escape/Tab.
 function _nh_clear_ghost {
+    if ($script:_nh_timer) { try { $script:_nh_timer.Stop() } catch {} }
     $script:_nh_state.generation++
     if ($script:_nh_state.ghost_len -gt 0) {
         $e = $script:_nh_esc
@@ -211,7 +216,23 @@ $script:_nh_worker = {
             return
         }
 
+        # Reject the suggestion outright if it contains any control char (<0x20 or 0x7f).
+        # A response containing ESC (OSC 52 clipboard, DECSET, OSC 8 hyperlink, cursor
+        # moves) hijacks the terminal during render; a newline (0x0a) auto-submits on
+        # accept, which is a single-keystroke RCE if the model emits `rm -rf $HOME\n`.
+        # Fail-closed (reject) over fail-open (strip): stripping concatenates around
+        # dropped chars (`ls\x00rm` -> `lsrm`), silently merging tokens. Shell commands
+        # never legitimately contain control chars, so reject has zero false-positive cost.
         $text = [string]$s.text
+        foreach ($_nh_ch in $text.ToCharArray()) {
+            $_nh_ch_code = [int]$_nh_ch
+            if ($_nh_ch_code -lt 0x20 -or $_nh_ch_code -eq 0x7f) {
+                & $writeLog "rejected: suggestion contains control char 0x$('{0:x2}' -f $_nh_ch_code)"
+                return
+            }
+        }
+        if (-not $text) { return }
+
         $rstart = [int]$s.replace_start
         $rend = [int]$s.replace_end
 
@@ -242,6 +263,20 @@ $script:_nh_worker = {
             text  = $text
             start = $rstart
             end   = $rend
+        }
+        # Post-publish fence: if foreground bumped generation between our staleness check
+        # and the assignment above, our publish + console-write are both stale. Undo BOTH
+        # state and display: null published (so Tab can't insert a phantom) AND emit the
+        # clear sequence (so a stale ghost doesn't linger on screen). The display undo is
+        # required when foreground's racing partner was _nh_query (typing) rather than
+        # _nh_clear_ghost — _nh_query advances generation but does NOT clear the screen,
+        # so without this, multi-line wrapped ghosts would linger until Enter. Idempotent:
+        # if _nh_clear_ghost already ran, the extra clear is a no-op.
+        if ($state.generation -ne $myGen) {
+            [System.Console]::Write("${e}[s${e}[0J${e}[u")
+            $state.published = $null
+            $state.ghost_len = 0
+            return
         }
         & $writeLog "rendered ghost (len=$($ghost.Length))"
     } catch {
@@ -304,11 +339,19 @@ $null = Register-ObjectEvent -InputObject $script:_nh_timer -EventName Elapsed `
 
         # Dispatch to a pooled runspace. BeginInvoke returns immediately — the event-handler
         # runspace (pumped on the main pipeline thread) is freed before the IPC happens.
+        # If AddScript/BeginInvoke throws (e.g., pool closing during reload), the created
+        # [PowerShell] instance would leak — dispose it unless ownership transferred to
+        # $inflight. Set $ps = $null after Add so finally only disposes orphans.
         $ps = [PowerShell]::Create()
-        $ps.RunspacePool = $data.pool
-        $null = $ps.AddScript($data.worker_text).AddArgument($state)
-        $iar = $ps.BeginInvoke()
-        $inflight.Add(@{ ps = $ps; iar = $iar })
+        try {
+            $ps.RunspacePool = $data.pool
+            $null = $ps.AddScript($data.worker_text).AddArgument($state)
+            $iar = $ps.BeginInvoke()
+            $inflight.Add(@{ ps = $ps; iar = $iar })
+            $ps = $null
+        } finally {
+            if ($ps) { try { $ps.Dispose() } catch {} }
+        }
     } catch {
         if ($state.debug) {
             try {
@@ -361,9 +404,11 @@ function _nh_accept {
         $end = [int]$snap['end']
         # Buffer may have shrunk since the worker captured the suggestion; re-read it so
         # PSReadLine.Replace doesn't throw ArgumentOutOfRangeException on a stale end.
+        # Also defend against malformed ranges (start past end-of-buffer, inverted range)
+        # in case a future tier returns bad values.
         $current = ''; $cur = 0
         [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$current, [ref]$cur)
-        if ($end -gt $current.Length) { return }
+        if ($end -lt 0 -or $end -gt $current.Length -or $start -gt $current.Length -or $end -lt $start) { return }
         _nh_clear_ghost
         $len = $end - $start
         [Microsoft.PowerShell.PSConsoleReadLine]::Replace($start, $len, $text)

--- a/src/daemon/config.rs
+++ b/src/daemon/config.rs
@@ -47,12 +47,71 @@ impl Default for TierConfig {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum CloudProvider {
+    #[default]
+    OpenAI,
+    Anthropic,
+    Groq,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(default)]
 pub struct CloudConfig {
-    pub provider: String,
+    pub provider: CloudProvider,
     pub api_key: Option<String>,
     pub model: Option<String>,
     pub base_url: Option<String>,
+    pub budget_ms: u32,
+    pub history_context_size: usize,
+    pub max_tokens: u32,
+    pub temperature: f32,
+}
+
+impl Default for CloudConfig {
+    fn default() -> Self {
+        Self {
+            provider: CloudProvider::OpenAI,
+            api_key: None,
+            model: None,
+            base_url: None,
+            budget_ms: 2000,
+            history_context_size: 10,
+            max_tokens: 150,
+            temperature: 0.2,
+        }
+    }
+}
+
+impl CloudConfig {
+    /// Get API key from config or environment variable
+    pub fn api_key(&self) -> Option<String> {
+        self.api_key.clone().or_else(|| {
+            let var = match self.provider {
+                CloudProvider::OpenAI => "OPENAI_API_KEY",
+                CloudProvider::Anthropic => "ANTHROPIC_API_KEY",
+                CloudProvider::Groq => "GROQ_API_KEY",
+            };
+            std::env::var(var).ok()
+        })
+    }
+
+    pub fn default_model(&self) -> &'static str {
+        match self.provider {
+            CloudProvider::OpenAI => "gpt-4o-mini",
+            CloudProvider::Anthropic => "claude-3-5-haiku-latest",
+            CloudProvider::Groq => "llama-3.3-70b-versatile",
+        }
+    }
+
+    pub fn default_base_url(&self) -> &'static str {
+        match self.provider {
+            CloudProvider::OpenAI => "https://api.openai.com/v1",
+            CloudProvider::Anthropic => "https://api.anthropic.com",
+            CloudProvider::Groq => "https://api.groq.com/openai/v1",
+        }
+    }
 }
 
 /// Configuration for the local LLM tier (Tier 2).
@@ -198,5 +257,49 @@ temperature = 0
         let config: Config = toml::from_str(toml_str).unwrap();
         let llm = config.local_llm.unwrap();
         assert_eq!(llm.temperature, 0.0);
+    }
+
+    #[test]
+    fn parse_cloud_config() {
+        let toml_str = r#"
+[tiers]
+enable_cloud = true
+
+[cloud]
+provider = "anthropic"
+budget_ms = 1500
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert!(config.tiers.enable_cloud);
+        let cloud = config.cloud.unwrap();
+        assert_eq!(cloud.provider, CloudProvider::Anthropic);
+        assert_eq!(cloud.budget_ms, 1500);
+    }
+
+    #[test]
+    fn default_cloud_config() {
+        let cloud = CloudConfig::default();
+        assert_eq!(cloud.provider, CloudProvider::OpenAI);
+        assert_eq!(cloud.budget_ms, 2000);
+        assert_eq!(cloud.history_context_size, 10);
+        assert_eq!(cloud.max_tokens, 150);
+    }
+
+    #[test]
+    fn cloud_config_default_model() {
+        let cloud = CloudConfig::default();
+        assert_eq!(cloud.default_model(), "gpt-4o-mini");
+
+        let anthropic = CloudConfig {
+            provider: CloudProvider::Anthropic,
+            ..Default::default()
+        };
+        assert_eq!(anthropic.default_model(), "claude-3-5-haiku-latest");
+
+        let groq = CloudConfig {
+            provider: CloudProvider::Groq,
+            ..Default::default()
+        };
+        assert_eq!(groq.default_model(), "llama-3.3-70b-versatile");
     }
 }

--- a/src/daemon/engine/cloud.rs
+++ b/src/daemon/engine/cloud.rs
@@ -1,0 +1,466 @@
+//! Cloud LLM Tier (Tier 3): Intent-aware command synthesis using cloud APIs.
+//!
+//! Unlike the local LLM tier which does token completion, this tier reasons
+//! about what the user is trying to accomplish and suggests sophisticated
+//! commands they may not have known to type.
+
+use super::tier::PredictionTier;
+use crate::daemon::config::{CloudConfig, CloudProvider};
+use crate::daemon::history::file::FileHistory;
+use crate::proto::{CompletionRequest, Shell, Suggestion, SuggestionSource};
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+use tracing::{debug, warn};
+
+const SYSTEM_PROMPT: &str = r#"You are an expert terminal command synthesizer. Analyze the user's INTENT based on their partial command and recent history, then suggest a sophisticated command they may not have known to type.
+
+OUTPUT FORMAT (exactly two lines):
+COMMAND: <complete shell command>
+DESCRIPTION: <5-10 word explanation of what this does>
+
+RULES:
+- Suggest ONE complete, ready-to-execute command
+- Include useful flags the user might not know
+- Consider the working directory and shell type
+- The description MUST explain what the command does (for user safety)
+- If you cannot suggest anything useful, output: NONE
+
+EXAMPLES:
+Input: "docker logs" after container issues
+COMMAND: docker logs myapp --tail 100 --follow
+DESCRIPTION: Stream last 100 log lines from myapp container
+
+Input: "find ." in a git repo
+COMMAND: find . -type f -name '*.rs' -mtime -1
+DESCRIPTION: Find Rust files modified in the last day
+
+Input: "git log"
+COMMAND: git log --oneline --graph -20
+DESCRIPTION: Show visual commit graph of last 20 commits"#;
+
+// ── OpenAI-compatible API types ─────────────────────────────────
+
+#[derive(Serialize)]
+struct ChatRequest {
+    model: String,
+    messages: Vec<ChatMessage>,
+    temperature: f32,
+    max_tokens: u32,
+    stream: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    stop: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct ChatMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct ChatResponse {
+    choices: Vec<ChatChoice>,
+}
+
+#[derive(Deserialize)]
+struct ChatChoice {
+    message: ChatResponseMessage,
+}
+
+#[derive(Deserialize)]
+struct ChatResponseMessage {
+    content: Option<String>,
+}
+
+// ── Provider trait for extensibility ────────────────────────────
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProviderError {
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("Authentication failed (401/403) — check API key")]
+    Auth,
+    #[error("Rate limited (429) — try again later")]
+    RateLimited,
+    #[error("API error ({0})")]
+    Api(u16),
+    #[error("Empty response from provider")]
+    EmptyResponse,
+}
+
+/// Trait for cloud LLM providers. Implement this to add new providers.
+#[async_trait]
+trait CloudProviderImpl: Send + Sync {
+    async fn complete(&self, system: &str, user: &str) -> Result<String, ProviderError>;
+}
+
+// ── OpenAI-compatible provider (OpenAI + Groq) ──────────────────
+
+struct OpenAICompatProvider {
+    client: Client,
+    base_url: String,
+    api_key: String,
+    model: String,
+    max_tokens: u32,
+    temperature: f32,
+}
+
+#[async_trait]
+impl CloudProviderImpl for OpenAICompatProvider {
+    async fn complete(&self, system: &str, user: &str) -> Result<String, ProviderError> {
+        let url = format!("{}/chat/completions", self.base_url.trim_end_matches('/'));
+        let req = ChatRequest {
+            model: self.model.clone(),
+            messages: vec![
+                ChatMessage {
+                    role: "system".into(),
+                    content: system.into(),
+                },
+                ChatMessage {
+                    role: "user".into(),
+                    content: user.into(),
+                },
+            ],
+            temperature: self.temperature,
+            max_tokens: self.max_tokens,
+            stream: false,
+            stop: vec![],
+        };
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .json(&req)
+            .send()
+            .await?;
+
+        match resp.status().as_u16() {
+            401 | 403 => return Err(ProviderError::Auth),
+            429 => return Err(ProviderError::RateLimited),
+            s if s >= 400 => return Err(ProviderError::Api(s)),
+            _ => {}
+        }
+
+        let chat_resp: ChatResponse = resp.json().await?;
+        chat_resp
+            .choices
+            .first()
+            .and_then(|c| c.message.content.clone())
+            .ok_or(ProviderError::EmptyResponse)
+    }
+}
+
+// ── Anthropic provider ──────────────────────────────────────────
+
+struct AnthropicProvider {
+    client: Client,
+    base_url: String,
+    api_key: String,
+    model: String,
+    max_tokens: u32,
+    temperature: f32,
+}
+
+#[async_trait]
+impl CloudProviderImpl for AnthropicProvider {
+    async fn complete(&self, system: &str, user: &str) -> Result<String, ProviderError> {
+        let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
+
+        let body = serde_json::json!({
+            "model": self.model,
+            "max_tokens": self.max_tokens,
+            "system": system,
+            "messages": [{"role": "user", "content": user}],
+            "temperature": self.temperature
+        });
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", "2023-06-01")
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await?;
+
+        match resp.status().as_u16() {
+            401 | 403 => return Err(ProviderError::Auth),
+            429 => return Err(ProviderError::RateLimited),
+            s if s >= 400 => return Err(ProviderError::Api(s)),
+            _ => {}
+        }
+
+        let json: serde_json::Value = resp.json().await?;
+        json["content"][0]["text"]
+            .as_str()
+            .map(String::from)
+            .ok_or(ProviderError::EmptyResponse)
+    }
+}
+
+// ── CloudTier implementation ────────────────────────────────────
+
+pub struct CloudTier {
+    provider: Box<dyn CloudProviderImpl>,
+    config: CloudConfig,
+    histories: Arc<RwLock<[FileHistory; 5]>>,
+    has_warned: AtomicBool,
+}
+
+impl CloudTier {
+    /// Create CloudTier. Returns None if API key is missing (logs warning).
+    pub fn new(config: CloudConfig, histories: Arc<RwLock<[FileHistory; 5]>>) -> Option<Self> {
+        let api_key = match config.api_key() {
+            Some(key) => key,
+            None => {
+                let env_var = match config.provider {
+                    CloudProvider::OpenAI => "OPENAI_API_KEY",
+                    CloudProvider::Anthropic => "ANTHROPIC_API_KEY",
+                    CloudProvider::Groq => "GROQ_API_KEY",
+                };
+                warn!(
+                    provider = ?config.provider,
+                    "Cloud LLM tier disabled: set {} or cloud.api_key in config",
+                    env_var
+                );
+                return None;
+            }
+        };
+
+        let model = config
+            .model
+            .clone()
+            .unwrap_or_else(|| config.default_model().to_string());
+        let base_url = config
+            .base_url
+            .clone()
+            .unwrap_or_else(|| config.default_base_url().to_string());
+
+        // HTTP timeout with safety margin
+        let http_timeout = config.budget_ms.saturating_sub(100);
+        let client = match Client::builder()
+            .connect_timeout(Duration::from_millis(500))
+            .timeout(Duration::from_millis(http_timeout as u64))
+            .build()
+        {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(error = %e, "Failed to create HTTP client for cloud tier");
+                return None;
+            }
+        };
+
+        let provider: Box<dyn CloudProviderImpl> = match config.provider {
+            CloudProvider::OpenAI | CloudProvider::Groq => Box::new(OpenAICompatProvider {
+                client,
+                base_url,
+                api_key,
+                model,
+                max_tokens: config.max_tokens,
+                temperature: config.temperature,
+            }),
+            CloudProvider::Anthropic => Box::new(AnthropicProvider {
+                client,
+                base_url,
+                api_key,
+                model,
+                max_tokens: config.max_tokens,
+                temperature: config.temperature,
+            }),
+        };
+
+        Some(Self {
+            provider,
+            config,
+            histories,
+            has_warned: AtomicBool::new(false),
+        })
+    }
+
+    /// Get recent commands from shell history (stateless read at request time)
+    async fn get_recent_history(&self, shell: Shell, limit: usize) -> Vec<String> {
+        let histories = self.histories.read().await;
+        let idx = shell.index();
+        histories[idx]
+            .entries()
+            .iter()
+            .take(limit)
+            .map(|e| e.command.clone())
+            .collect()
+    }
+}
+
+#[async_trait]
+impl PredictionTier for CloudTier {
+    fn name(&self) -> &str {
+        "cloud-llm"
+    }
+
+    fn budget_ms(&self) -> u32 {
+        self.config.budget_ms
+    }
+
+    async fn predict(&self, req: &CompletionRequest) -> Vec<Suggestion> {
+        let input = &req.input[..req.cursor];
+        if input.trim().is_empty() {
+            return vec![];
+        }
+
+        // Get recent history (stateless read)
+        let history = self
+            .get_recent_history(req.shell, self.config.history_context_size)
+            .await;
+
+        // Build prompt
+        let history_text = if history.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "\n\nRecent commands:\n{}",
+                history
+                    .iter()
+                    .map(|c| format!("- {}", c))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )
+        };
+
+        let user_prompt = format!(
+            "Shell: {}\nWorking directory: {}\nCurrent input: {}{}",
+            req.shell.as_str(),
+            req.cwd.display(),
+            input,
+            history_text
+        );
+
+        // Call provider
+        let raw = match self.provider.complete(SYSTEM_PROMPT, &user_prompt).await {
+            Ok(r) => r,
+            Err(ProviderError::Auth) => {
+                warn!("Cloud LLM: authentication failed — check API key");
+                return vec![];
+            }
+            Err(ProviderError::RateLimited) => {
+                warn!("Cloud LLM: rate limited (429) — try again later");
+                return vec![];
+            }
+            Err(e) => {
+                if self
+                    .has_warned
+                    .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+                    .is_ok()
+                {
+                    warn!(error = %e, "Cloud LLM: request failed");
+                } else {
+                    debug!(error = %e, "Cloud LLM request failed");
+                }
+                return vec![];
+            }
+        };
+
+        // Parse response
+        let (command, description) = parse_cloud_response(&raw);
+        let Some(command) = command else {
+            return vec![];
+        };
+
+        vec![Suggestion {
+            text: command,
+            replace_start: 0,
+            replace_end: req.input.len(),
+            confidence: 0.7,
+            source: SuggestionSource::CloudModel,
+            description,
+            diff_ops: None,
+        }]
+    }
+}
+
+fn parse_cloud_response(raw: &str) -> (Option<String>, Option<String>) {
+    let raw = raw.trim();
+    if raw.eq_ignore_ascii_case("none") {
+        return (None, None);
+    }
+
+    let mut command = None;
+    let mut description = None;
+
+    for line in raw.lines() {
+        let line = line.trim();
+        if let Some(cmd) = line.strip_prefix("COMMAND:") {
+            command = Some(cmd.trim().to_string());
+        } else if let Some(desc) = line.strip_prefix("DESCRIPTION:") {
+            description = Some(desc.trim().to_string());
+        }
+    }
+
+    // Fallback: first non-empty line as command
+    if command.is_none() {
+        command = raw
+            .lines()
+            .find(|l| !l.trim().is_empty())
+            .map(|l| l.trim().to_string());
+    }
+
+    (command, description)
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_structured_response() {
+        let raw = "COMMAND: docker logs myapp --tail 100\nDESCRIPTION: Show last 100 log lines";
+        let (cmd, desc) = parse_cloud_response(raw);
+        assert_eq!(cmd, Some("docker logs myapp --tail 100".into()));
+        assert_eq!(desc, Some("Show last 100 log lines".into()));
+    }
+
+    #[test]
+    fn parse_none_response() {
+        let (cmd, desc) = parse_cloud_response("NONE");
+        assert!(cmd.is_none());
+        assert!(desc.is_none());
+
+        let (cmd, desc) = parse_cloud_response("none");
+        assert!(cmd.is_none());
+        assert!(desc.is_none());
+    }
+
+    #[test]
+    fn parse_fallback_unstructured() {
+        let raw = "git log --oneline -20";
+        let (cmd, desc) = parse_cloud_response(raw);
+        assert_eq!(cmd, Some("git log --oneline -20".into()));
+        assert!(desc.is_none());
+    }
+
+    #[test]
+    fn parse_with_extra_whitespace() {
+        let raw = "  COMMAND:   find . -name '*.rs'  \n  DESCRIPTION:   Find Rust files  ";
+        let (cmd, desc) = parse_cloud_response(raw);
+        assert_eq!(cmd, Some("find . -name '*.rs'".into()));
+        assert_eq!(desc, Some("Find Rust files".into()));
+    }
+
+    #[test]
+    fn parse_empty_response() {
+        let (cmd, desc) = parse_cloud_response("");
+        assert!(cmd.is_none());
+        assert!(desc.is_none());
+
+        let (cmd, desc) = parse_cloud_response("   \n   ");
+        assert!(cmd.is_none());
+        assert!(desc.is_none());
+    }
+}

--- a/src/daemon/engine/cloud.rs
+++ b/src/daemon/engine/cloud.rs
@@ -11,11 +11,16 @@ use crate::proto::{CompletionRequest, Shell, Suggestion, SuggestionSource};
 use async_trait::async_trait;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
 use tracing::{debug, warn};
+
+// Minimum interval between identical-message warns from maybe_warn(); within the
+// window, subsequent failures log at debug. Prevents per-keystroke warn spam during
+// sustained outages while still ensuring persistent issues remain visible.
+const WARN_REWARN_WINDOW_MS: u64 = 5 * 60 * 1000;
 
 const SYSTEM_PROMPT: &str = r#"You are an expert terminal command synthesizer. Analyze the user's INTENT based on their partial command and recent history, then suggest a sophisticated command they may not have known to type.
 
@@ -211,7 +216,7 @@ pub struct CloudTier {
     provider: Box<dyn CloudProviderImpl>,
     config: CloudConfig,
     histories: Arc<RwLock<[FileHistory; 5]>>,
-    has_warned: AtomicBool,
+    last_warn_ms: AtomicU64,
 }
 
 impl CloudTier {
@@ -280,8 +285,26 @@ impl CloudTier {
             provider,
             config,
             histories,
-            has_warned: AtomicBool::new(false),
+            last_warn_ms: AtomicU64::new(0),
         })
+    }
+
+    /// Throttled warn — emits at most one warn per WARN_REWARN_WINDOW_MS across all error
+    /// variants. Demoted occurrences still log at debug. Race-tolerant: if two callers
+    /// observe the same `last`, only one wins the CAS and warns.
+    fn maybe_warn(&self, e: &ProviderError) {
+        let now = now_ms();
+        let last = self.last_warn_ms.load(Ordering::Relaxed);
+        if now.saturating_sub(last) >= WARN_REWARN_WINDOW_MS
+            && self
+                .last_warn_ms
+                .compare_exchange(last, now, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+        {
+            warn!(error = %e, "Cloud LLM request failed");
+        } else {
+            debug!(error = %e, "Cloud LLM request failed");
+        }
     }
 
     /// Get recent commands from shell history (stateless read at request time)
@@ -295,6 +318,13 @@ impl CloudTier {
             .map(|e| e.command.clone())
             .collect()
     }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
 }
 
 #[async_trait]
@@ -340,27 +370,11 @@ impl PredictionTier for CloudTier {
             history_text
         );
 
-        // Call provider
+        // Call provider — all error variants share a single throttled warn window.
         let raw = match self.provider.complete(SYSTEM_PROMPT, &user_prompt).await {
             Ok(r) => r,
-            Err(ProviderError::Auth) => {
-                warn!("Cloud LLM: authentication failed — check API key");
-                return vec![];
-            }
-            Err(ProviderError::RateLimited) => {
-                warn!("Cloud LLM: rate limited (429) — try again later");
-                return vec![];
-            }
             Err(e) => {
-                if self
-                    .has_warned
-                    .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
-                    .is_ok()
-                {
-                    warn!(error = %e, "Cloud LLM: request failed");
-                } else {
-                    debug!(error = %e, "Cloud LLM request failed");
-                }
+                self.maybe_warn(&e);
                 return vec![];
             }
         };
@@ -391,22 +405,34 @@ fn parse_cloud_response(raw: &str) -> (Option<String>, Option<String>) {
 
     let mut command = None;
     let mut description = None;
+    // Track whether the model emitted structured output at all. If it did but with an
+    // empty COMMAND, honor that as "no suggestion" rather than salvaging from another line.
+    let mut saw_structured = false;
 
     for line in raw.lines() {
         let line = line.trim();
         if let Some(cmd) = line.strip_prefix("COMMAND:") {
-            command = Some(cmd.trim().to_string());
+            saw_structured = true;
+            let cmd = cmd.trim();
+            if !cmd.is_empty() {
+                command = Some(cmd.to_string());
+            }
         } else if let Some(desc) = line.strip_prefix("DESCRIPTION:") {
-            description = Some(desc.trim().to_string());
+            saw_structured = true;
+            let desc = desc.trim();
+            if !desc.is_empty() {
+                description = Some(desc.to_string());
+            }
         }
     }
 
-    // Fallback: first non-empty line as command
-    if command.is_none() {
+    // Fallback only when the response was unstructured. First non-empty line as command.
+    if command.is_none() && !saw_structured {
         command = raw
             .lines()
-            .find(|l| !l.trim().is_empty())
-            .map(|l| l.trim().to_string());
+            .map(str::trim)
+            .find(|l| !l.is_empty())
+            .map(String::from);
     }
 
     (command, description)
@@ -462,5 +488,18 @@ mod tests {
         let (cmd, desc) = parse_cloud_response("   \n   ");
         assert!(cmd.is_none());
         assert!(desc.is_none());
+    }
+
+    #[test]
+    fn parse_empty_command_value_is_none() {
+        // Model emits the structured prefix with an empty value — must NOT become Some("").
+        // Otherwise the cloud suggestion would have text="" and full-buffer replace, wiping
+        // the user's typed input on accept.
+        let (cmd, desc) = parse_cloud_response("COMMAND:\nDESCRIPTION: nothing");
+        assert!(cmd.is_none());
+        assert_eq!(desc, Some("nothing".into()));
+
+        let (cmd, _) = parse_cloud_response("COMMAND:   \n");
+        assert!(cmd.is_none());
     }
 }

--- a/src/daemon/engine/history.rs
+++ b/src/daemon/engine/history.rs
@@ -1,6 +1,7 @@
 use crate::daemon::fuzzy;
 use crate::proto::{CompletionRequest, Shell, Suggestion, SuggestionSource};
 use async_trait::async_trait;
+use std::sync::Arc;
 
 use super::tier::PredictionTier;
 use crate::daemon::history::file::FileHistory;
@@ -11,7 +12,7 @@ use tokio::sync::RwLock;
 /// Looks up commands the user has typed before, ranked by recency/frequency.
 /// Must complete in under 1ms.
 pub struct HistoryTier {
-    histories: RwLock<[FileHistory; 5]>,
+    histories: Arc<RwLock<[FileHistory; 5]>>,
 }
 
 impl Default for HistoryTier {
@@ -37,8 +38,19 @@ impl HistoryTier {
             h
         });
         Self {
-            histories: RwLock::new(histories),
+            histories: Arc::new(RwLock::new(histories)),
         }
+    }
+
+    /// Create HistoryTier with shared history storage.
+    /// Used when history needs to be shared with other tiers (e.g., CloudTier).
+    pub fn with_shared_histories(histories: Arc<RwLock<[FileHistory; 5]>>) -> Self {
+        Self { histories }
+    }
+
+    /// Get a clone of the shared history Arc for use by other tiers (e.g., CloudTier).
+    pub fn shared_histories(&self) -> Arc<RwLock<[FileHistory; 5]>> {
+        Arc::clone(&self.histories)
     }
 
     /// Create a HistoryTier with a single pre-loaded history.
@@ -56,7 +68,7 @@ impl HistoryTier {
         let mut histories: [FileHistory; 5] = std::array::from_fn(|i| FileHistory::new(shells[i]));
         histories[idx] = history;
         Self {
-            histories: RwLock::new(histories),
+            histories: Arc::new(RwLock::new(histories)),
         }
     }
 }

--- a/src/daemon/engine/history.rs
+++ b/src/daemon/engine/history.rs
@@ -48,11 +48,6 @@ impl HistoryTier {
         Self { histories }
     }
 
-    /// Get a clone of the shared history Arc for use by other tiers (e.g., CloudTier).
-    pub fn shared_histories(&self) -> Arc<RwLock<[FileHistory; 5]>> {
-        Arc::clone(&self.histories)
-    }
-
     /// Create a HistoryTier with a single pre-loaded history.
     /// Other shells will have empty histories. Useful for testing.
     pub fn with_history(history: FileHistory) -> Self {

--- a/src/daemon/engine/mod.rs
+++ b/src/daemon/engine/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "cloud-llm")]
+pub mod cloud;
 pub mod history;
 #[cfg(feature = "local-llm")]
 pub mod llm;

--- a/src/daemon/history/file.rs
+++ b/src/daemon/history/file.rs
@@ -45,6 +45,11 @@ impl FileHistory {
         self.shell
     }
 
+    /// Get all history entries (for context in other tiers like CloudTier)
+    pub fn entries(&self) -> &[HistoryEntry] {
+        &self.entries
+    }
+
     /// Check if history file changed since last load, reload if so.
     /// Returns silently on any error (file locked, inaccessible, etc.) — uses cached results.
     ///

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -27,9 +27,35 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // Build prediction tiers
     let mut tiers: Vec<Box<dyn engine::tier::PredictionTier>> = Vec::new();
 
-    // Tier 0: History (loads all shells eagerly, selects per-request via req.shell)
+    // Create shared history storage (used by HistoryTier and optionally CloudTier)
+    let shared_histories: std::sync::Arc<tokio::sync::RwLock<[history::file::FileHistory; 5]>> = {
+        use crate::proto::Shell;
+        use history::file::FileHistory;
+        use history::ShellHistory;
+        let shells = [
+            Shell::Zsh,
+            Shell::Bash,
+            Shell::Fish,
+            Shell::PowerShell,
+            Shell::Nushell,
+        ];
+        let histories: [FileHistory; 5] = std::array::from_fn(|i| {
+            let mut h = FileHistory::new(shells[i]);
+            if let Err(e) = h.load() {
+                tracing::debug!(shell = shells[i].as_str(), error = %e, "No history file");
+            }
+            h
+        });
+        std::sync::Arc::new(tokio::sync::RwLock::new(histories))
+    };
+
+    // Tier 0: History (uses shared history storage)
     if config.tiers.enable_history {
-        tiers.push(Box::new(engine::history::HistoryTier::new()));
+        tiers.push(Box::new(
+            engine::history::HistoryTier::with_shared_histories(std::sync::Arc::clone(
+                &shared_histories,
+            )),
+        ));
         tracing::debug!("History tier enabled (multi-shell)");
     }
 
@@ -83,6 +109,36 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
         tracing::warn!(
             "enable_local_llm is set but nighthawk was compiled without the 'local-llm' feature. \
              Reinstall with: cargo install nighthawk --features local-llm"
+        );
+    }
+
+    // Tier 3: Cloud LLM (independent of local-llm, shares history with HistoryTier)
+    #[cfg(feature = "cloud-llm")]
+    if config.tiers.enable_cloud {
+        let cloud_config = config.cloud.clone().unwrap_or_default();
+        match engine::cloud::CloudTier::new(
+            cloud_config.clone(),
+            std::sync::Arc::clone(&shared_histories),
+        ) {
+            Some(tier) => {
+                tracing::info!(
+                    provider = ?cloud_config.provider,
+                    model = %cloud_config.model.clone().unwrap_or_else(|| cloud_config.default_model().to_string()),
+                    "Cloud LLM tier enabled"
+                );
+                tiers.push(Box::new(tier));
+            }
+            None => {
+                // Warning already logged by CloudTier::new()
+            }
+        }
+    }
+
+    #[cfg(not(feature = "cloud-llm"))]
+    if config.tiers.enable_cloud {
+        tracing::warn!(
+            "enable_cloud is set but nighthawk was compiled without the 'cloud-llm' feature. \
+             Reinstall with: cargo install nighthawk --features cloud-llm"
         );
     }
 


### PR DESCRIPTION
## Summary

- Adds **Tier 3 cloud LLM** with intent-aware command synthesis. Providers: OpenAI, Anthropic, Groq. Opt-in via `--features cloud-llm`, `enable_cloud = false` by default. BYOK via env var or `cloud.api_key` config.
- Fixes the **PowerShell plugin 2 s keystroke freeze** on cloud calls by moving IPC off the event-handler runspace via a `RunspacePool` worker. Root cause: scriptblocks need a Runspace in TLS or the CLR fast-fails the entire `pwsh` process (`0xE0434352`) — documented in `CLAUDE.md` under "What NOT to do."
- Hardens the plugin: `[PowerShell]` instance disposal via prune-on-dispatch, buffer-length race guards, cached UTF-8 encoding, redundant `Test-Path` probes removed.

## What's new — Tier 3 cloud LLM

- `src/daemon/engine/cloud.rs` — `CloudTier` with `CloudProviderImpl` trait. OpenAI-compatible (OpenAI + Groq) and Anthropic implementations. Errors classified into `Auth` (401/403) / `RateLimited` (429) / `Api(status)` / `EmptyResponse` with distinct logging.
- Structured prompt format: `COMMAND: ...\nDESCRIPTION: ...`, with a fallback parser for unstructured replies. Five unit tests cover the parser.
- Recent shell history (default 10 commands) included in the prompt for context.
- API key resolution: explicit `cloud.api_key` in `config.toml` wins, falls back to provider-specific env var (`OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GROQ_API_KEY`).
- HTTP timeout is `budget_ms - 100ms` slack; default `budget_ms = 2000`.

## What's new — PowerShell plugin

- `shells/nighthawk.ps1` reworked to dispatch IPC into a `RunspacePool(1, 3)` worker via `[PowerShell]::Create().BeginInvoke()`. The Action handler returns immediately; the keystroke pipeline never blocks.
- Switched JSON parsing from `JavaScriptSerializer` (`System.Web`, .NET Framework only) to `ConvertFrom-Json` (works on PS 5.1 + PS 7+).
- Prune-on-dispatch releases completed `[PowerShell]` instances + their `IAsyncResult` kernel handles — bounded leak by pool size.
- Race guards: `_nh_accept` re-reads the live buffer length before `PSReadLine.Replace`; worker validates `$rstart + $typed_len <= $line.Length` before `Substring`.

## Verification

- **Automated**: 19/19 checks pass via a one-off `pwsh -NoProfile` script covering state shape, pool config, re-source idempotency, dispatch+prune cycle, and stale-generation gate. Script deleted after passing.
- **Interactive**: smooth typing with Tier 3 enabled, no perceptible freeze.
- **Three providers verified end-to-end** via `nh complete`: Groq (default), Anthropic (with `model = "claude-haiku-4-5-20251001"` override since source default `claude-3-5-haiku-latest` 404s on current API), OpenAI (`gpt-4o-mini` default).

## Test plan

- [x] `cargo build --release --features cloud-llm` succeeds (verified `--all-features` 2026-05-25)
- [x] `cargo test --features cloud-llm` passes (214 tests: 207 unit + 7 integration, all green)
- [x] `nh complete "find all png files modified in the last week and resize"` returns structured suggestion via Groq (~570ms round-trip)
- [x] Type interactively in PS7 — ghost text appears without keystroke freeze
- [x] PS5.1 source-load clean — `_nh_state` initializes, no PSReadLine / RunspacePool exceptions on init
- [x] `_nh_accept` race guard verified — invoking with stale `end=99` against an empty buffer returns silently, no `ArgumentOutOfRangeException`
- [x] Re-source plugin 3× — `Get-EventSubscriber -SourceIdentifier 'nh_debounce'` returns count `1` (teardown at nighthawk.ps1:256–262)
- [x] Kill daemon mid-typing — plugin.log shows 7 `bg-FATAL: ... Connect ... timed out` entries with the `pwsh` host process surviving every time

## Follow-ups (separate PRs)

- Source default `claude-3-5-haiku-latest` 404s on current Anthropic API; update to a stable alias.
- README cloud-tier setup walkthrough (this PR's README changes correct stale claims only).
- ANSI passthrough sanitization in plugin (defense in depth, not a regression).
- UTF-8 byte vs UTF-16 char offsets in `replace_start` / `replace_end` (currently masked by ASCII-only typing).
- Cut **v0.4.0** to crates.io after merge — v0.3.0 was tagged before this branch landed in main.