### PR TITLE
fix: history fuzzy fallback shipped replace_end=0, Tab inserted instead of replacing

### DIFF
--- a/src/daemon/engine/history.rs
+++ b/src/daemon/engine/history.rs
@@ -134,11 +134,12 @@ impl HistoryTier {
             return vec![];
         }
 
+        // Byte offset of the first token within input. find() cannot fail:
+        // first_token comes from split_whitespace() on this same input.
+        let token_start = input.find(first_token).unwrap_or(0);
+
         // Get the rest of the input after the first token
-        let rest = input
-            .find(first_token)
-            .map(|pos| &input[pos + first_token.len()..])
-            .unwrap_or("");
+        let rest = &input[token_start + first_token.len()..];
 
         // Get unique command names from history (preserves frequency order)
         let command_names = history.command_names();
@@ -192,8 +193,13 @@ impl HistoryTier {
             .into_iter()
             .map(|entry| Suggestion {
                 text: entry.command.clone(),
-                replace_start: 0, // Full replacement from start
-                replace_end: 0,   // Will be set by caller based on cursor
+                // Replace from the typo'd token through the cursor, preserving
+                // anything before the token (e.g. leading whitespace).
+                replace_start: token_start,
+                // input.len() == req.cursor: predict() passes &req.input[..req.cursor]
+                // (cursor assumed on a char boundary). Only valid while callers pass
+                // cursor-terminated slices.
+                replace_end: input.len(),
                 confidence,
                 source: SuggestionSource::History,
                 description: None,
@@ -234,7 +240,37 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].text, "claude remote-control");
         assert_eq!(results[0].replace_start, 0);
+        assert_eq!(results[0].replace_end, "cclaude rem".len());
+        assert_eq!(results[0].source, SuggestionSource::History);
         assert!(results[0].diff_ops.is_some());
+    }
+
+    /// Simulates the shell plugin's accept path: buffer[..start] + text + buffer[end..].
+    /// Guards issue #74 — fuzzy fallback shipped replace_end: 0, so Tab inserted the
+    /// suggestion at position 0 instead of replacing the typed input.
+    #[test]
+    fn fuzzy_accept_reconstructs_buffer() {
+        let history = create_history_with_entries(&["cargo build --release"]);
+
+        fn accept(buffer: &str, s: &Suggestion) -> String {
+            format!(
+                "{}{}{}",
+                &buffer[..s.replace_start],
+                s.text,
+                &buffer[s.replace_end..]
+            )
+        }
+
+        // Plain case: typo'd command plus rest of input
+        let results = HistoryTier::try_fuzzy_fallback("crago bu", &history);
+        assert_eq!(results.len(), 1);
+        assert_eq!(accept("crago bu", &results[0]), "cargo build --release");
+
+        // Leading whitespace is preserved: replacement starts at the token, not 0
+        let results = HistoryTier::try_fuzzy_fallback("  crago", &history);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].replace_start, 2);
+        assert_eq!(accept("  crago", &results[0]), "  cargo build --release");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`try_fuzzy_fallback` in the history tier shipped `Suggestion { replace_start: 0, replace_end: 0 }` with a comment promising the caller would set `replace_end` — no caller ever did. The render path only uses `text`, so ghost hints looked correct, but Tab-accept executed `Replace(0, 0, text)`: the corrected command was inserted at position 0 with the typed input left in place.

Fixes #74

## The fix

Replace from the typo'd token through the cursor:

- `replace_start: token_start` — the token's byte offset within the input (preserves anything before it, e.g. leading whitespace), reusing the `input.find(first_token)` the function already computed for `rest`. Matches the spec tier's `token_start` convention.
- `replace_end: input.len()` — equals `req.cursor`, because `predict()` passes `&req.input[..req.cursor]`. Documented at the fix site since the function signature alone can't enforce it.

## Tests

- `fuzzy_corrects_typo_in_command` now asserts the **full** Suggestion contract. The original test checked `replace_start` and `diff_ops` but never `replace_end` — the one field that was wrong.
- New `fuzzy_accept_reconstructs_buffer` simulates the shell plugins' exact accept arithmetic (`buffer[..start] + text + buffer[end..]`) for a plain case and a leading-whitespace case.
- Manually verified on PowerShell: `csl` + Tab and `gti st` + Tab now replace correctly, including with leading whitespace.

## Behavior change worth knowing: this activates tier shadowing

Git archaeology (see #74 comment) shows the spec tier has had a *correct* fuzzy correction since `e60c23e`. When #69 added the history-tier fuzzy, it began shadowing the spec tier for any typo'd command present in shell history — the engine is first-non-empty-tier-wins and HistoryTier registers first. While broken, that shadowing path was unusable; this fix makes it reliably fire. Net effect: history fuzzy (confidence 0.55–0.70) now answers queries the spec tier (0.85) used to handle, with both now producing protocol-valid output. Whether history fuzzy *should* outrank spec fuzzy is a design question deliberately left out of this PR — flagging it here for visibility.

## Out of scope (filed separately)

- PowerShell plugin treats the protocol's byte offsets as UTF-16 char offsets in `Replace()`/`Substring()` — latent on non-ASCII input, pre-existing, unaffected by this change for ASCII.