### PR TITLE
fix: PowerShell plugin treats protocol byte offsets as char offsets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,15 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+      # Before the cargo steps so a Rust build failure doesn't shadow plugin test results.
+      - name: Plugin tests (Pester)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          if (-not (Get-Module -ListAvailable Pester | Where-Object Version -ge ([version]'5.0'))) {
+              Install-Module Pester -Force -Scope CurrentUser -SkipPublisherCheck
+          }
+          Invoke-Pester shells/tests -CI
       - name: Build
         run: cargo build
       - name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,8 @@ Thumbs.db
 # Node (fig converter tool)
 node_modules/
 
+# Pester (-CI flag artifact)
+testResults.xml
+
 # Claude Code
 .claude/

--- a/shells/nighthawk.ps1
+++ b/shells/nighthawk.ps1
@@ -111,6 +111,9 @@ $script:_nh_worker = {
     param([hashtable]$state)
 
     # JSON escape: \\, \", \b, \f, \n, \r, \t, plus \uXXXX for any other 0x00-0x1F control chars.
+    # Invariant: chars >= 0x20 MUST pass through RAW, never as \uXXXX — the daemon's byte
+    # offsets over `input` only agree with our GetByteCount because both sides see
+    # identical UTF-8 on the wire.
     $jsonEscape = {
         param([string]$s)
         if ([string]::IsNullOrEmpty($s)) { return '' }
@@ -137,6 +140,37 @@ $script:_nh_worker = {
         return $sb.ToString()
     }
 
+    # Maps a UTF-8 byte offset (protocol domain) to a UTF-16 char index (.NET domain).
+    # Only this plugin needs conversion: the protocol and the zsh plugin are byte-native,
+    # but .NET string APIs (Substring, PSReadLine Replace) index by UTF-16 chars. Must be
+    # applied against the exact $line snapshot sent in the request — the round-trip check
+    # below is only valid for that string. Returns -1 for out-of-range or mid-code-point
+    # offsets (fail-closed, like the control-char rejection below). $utf8 MUST be the
+    # replacement-fallback encoder ($state.utf8) — a throwOnInvalidBytes instance would
+    # turn lone-surrogate buffers into worker-killing exceptions.
+    $byteToChar = {
+        param([string]$s, [int]$byteOffset, [System.Text.UTF8Encoding]$utf8)
+        if ($byteOffset -lt 0) { return -1 }
+        if ($byteOffset -eq 0) { return 0 }
+        $bytes = $utf8.GetBytes($s)
+        if ($byteOffset -gt $bytes.Length) { return -1 }
+        # Surrogate-pair aware and never throws (replacement fallback).
+        $chars = $utf8.GetCharCount($bytes, 0, $byteOffset)
+        # Can't fire on well-formed input; turns a would-be Substring throw into a clean reject.
+        if ($chars -gt $s.Length) { return -1 }
+        # A char index landing on a low surrogate splits an emoji's UTF-16 pair — and the
+        # round-trip below can false-pass on exactly that case: an offset 1 byte into a
+        # 4-byte sequence decodes to 1 replacement char, and the truncated prefix's lone
+        # high surrogate re-encodes to '?' (1 byte), coincidentally matching. Reject directly.
+        if ($chars -lt $s.Length -and [char]::IsLowSurrogate($s[$chars])) { return -1 }
+        # LOAD-BEARING: GetCharCount silently rounds a mid-code-point offset to a
+        # replacement char; re-encoding the prefix exposes the length mismatch. Together
+        # with the surrogate check above this is the mid-sequence rejection — do not
+        # remove either as "redundant".
+        if ($utf8.GetByteCount($s.Substring(0, $chars)) -ne $byteOffset) { return -1 }
+        return $chars
+    }
+
     # Worker-side log. $force=$true bypasses debug-gate so fatal exceptions always leave a trace.
     $writeLog = {
         param([string]$m, [bool]$force = $false)
@@ -156,9 +190,23 @@ $script:_nh_worker = {
 
         if (-not $line -or $line.Length -lt 2) { return }
 
+        # Torn pending_* snapshot (pending_buffer/pending_cursor are written non-atomically
+        # by a racing keystroke): the pair is garbage — drop the request rather than clamp;
+        # the generation check would discard the response anyway.
+        if ($cursor -lt 0 -or $cursor -gt $line.Length) { return }
+
+        # The protocol speaks UTF-8 byte offsets, but PSReadLine's cursor is a UTF-16 char
+        # index — convert for the request only; $cursor itself stays char-domain for the
+        # ghost math below. If the buffer ends in a lone surrogate, GetByteCount counts a
+        # substituted '?' (matching what the UTF-8 StreamWriter puts on the wire, so the
+        # daemon sees consistent input); reply offsets that don't line up then fail the
+        # byteToChar checks and we fail closed (no ghost), never corrupting the buffer.
+        $utf8 = $state.utf8
+        $cursor_bytes = $utf8.GetByteCount($line.Substring(0, $cursor))
+
         $esc_input = & $jsonEscape $line
         $esc_cwd = & $jsonEscape $cwd
-        $json = '{"input":"' + $esc_input + '","cursor":' + $cursor + ',"cwd":"' + $esc_cwd + '","shell":"powershell"}'
+        $json = '{"input":"' + $esc_input + '","cursor":' + $cursor_bytes + ',"cwd":"' + $esc_cwd + '","shell":"powershell"}'
 
         & $writeLog "sending request len=$($line.Length)"
 
@@ -169,7 +217,6 @@ $script:_nh_worker = {
         $response = $null
         try {
             $pipe.Connect(50)
-            $utf8 = $state.utf8
             $writer = [System.IO.StreamWriter]::new($pipe, $utf8)
             $writer.AutoFlush = $true
             $writer.WriteLine($json)
@@ -233,8 +280,20 @@ $script:_nh_worker = {
         }
         if (-not $text) { return }
 
-        $rstart = [int]$s.replace_start
-        $rend = [int]$s.replace_end
+        # Protocol byte offsets -> .NET char indices, converted against $line (the exact
+        # buffer snapshot sent in the request). Must happen BEFORE the diff_ops branch:
+        # both branches publish these values and _nh_accept feeds them to PSReadLine
+        # Replace(), which is char-indexed. The inverted-range check stays here (not just
+        # in _nh_accept): publishing an inverted range would render a ghost that accept
+        # bails on before _nh_clear_ghost, leaving it stuck on screen.
+        $rstart_bytes = [int]$s.replace_start
+        $rend_bytes = [int]$s.replace_end
+        $rstart = & $byteToChar $line $rstart_bytes $utf8
+        $rend = & $byteToChar $line $rend_bytes $utf8
+        if ($rstart -lt 0 -or $rend -lt 0 -or $rend -lt $rstart) {
+            & $writeLog "rejected: replace range bytes [$rstart_bytes,$rend_bytes) not on code-point boundary"
+            return
+        }
 
         $ghost = $null
         if ($s.PSObject.Properties['diff_ops'] -and $null -ne $s.diff_ops) {

--- a/shells/tests/converters.Tests.ps1
+++ b/shells/tests/converters.Tests.ps1
@@ -1,0 +1,141 @@
+# Pester 5+ tests for the $byteToChar converter embedded in the worker scriptblock of
+# shells/nighthawk.ps1 (issue #76: protocol speaks UTF-8 byte offsets, .NET speaks
+# UTF-16 char indices).
+#
+# The helper is extracted via AST rather than dot-sourcing the plugin, so none of the
+# plugin's side effects (PSReadLine key handlers, runspace pool, debounce timer) run
+# here. The converter is pure — all inputs arrive as params — which is what makes this
+# extraction sound.
+#
+# Run: Invoke-Pester shells/tests
+#
+# Non-ASCII test characters are built from code points (not literals) so the tests are
+# immune to file-encoding mishaps (e.g. Windows PowerShell 5.1 reading UTF-8-no-BOM as ANSI).
+
+BeforeAll {
+    $pluginPath = (Resolve-Path (Join-Path $PSScriptRoot '..\nighthawk.ps1')).Path
+    $tokens = $null
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($pluginPath, [ref]$tokens, [ref]$errors)
+    if ($errors.Count -gt 0) { throw "nighthawk.ps1 failed to parse: $($errors[0].Message)" }
+
+    # $byteToChar lives inside the worker scriptblock — the $true flag (recurse into
+    # nested scriptblocks) is mandatory.
+    $node = $ast.Find({ param($n)
+        $n -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+        $n.Left.Extent.Text -eq '$byteToChar' }, $true)
+    if (-not $node) {
+        throw "Could not find `$byteToChar assignment in nighthawk.ps1 — was it renamed?"
+    }
+    if ($node.Right -isnot [System.Management.Automation.Language.CommandExpressionAst] -or
+        $node.Right.Expression -isnot [System.Management.Automation.Language.ScriptBlockExpressionAst]) {
+        throw "`$byteToChar is no longer a literal scriptblock assignment — update this extraction."
+    }
+    $script:byteToChar = $node.Right.Expression.ScriptBlock.GetScriptBlock()
+
+    # Same construction as the plugin's $state.utf8: no BOM, replacement fallback.
+    $script:utf8 = [System.Text.UTF8Encoding]::new($false)
+
+    $script:eAcute = [string][char]0xE9                  # é — 2 UTF-8 bytes, 1 UTF-16 char
+    $script:cjk    = [string][char]0x4E2D                # 中 — 3 UTF-8 bytes, 1 UTF-16 char
+    $script:emoji  = [char]::ConvertFromUtf32(0x1F600)   # 😀 — 4 UTF-8 bytes, 2 UTF-16 chars (surrogate pair)
+}
+
+Describe 'byteToChar' {
+
+    Context 'ASCII (byte == char identity)' {
+        It 'maps offset 0 to 0' {
+            & $byteToChar 'git checkout' 0 $utf8 | Should -Be 0
+        }
+        It 'maps a mid-string offset identically' {
+            & $byteToChar 'git checkout' 4 $utf8 | Should -Be 4
+        }
+        It 'maps offset == byte length to string length (EOL boundary)' {
+            & $byteToChar 'git checkout' 12 $utf8 | Should -Be 12
+        }
+    }
+
+    Context '2-byte sequence (e-acute)' {
+        It 'shifts char index below byte index past the multibyte char' {
+            # "echo café build": é occupies bytes 8-9, so the space after it is byte 10 -> char 9
+            $s = "echo caf$eAcute build"
+            & $byteToChar $s 10 $utf8 | Should -Be 9
+        }
+        It 'rejects an offset landing mid-sequence' {
+            $s = "echo caf$eAcute build"
+            & $byteToChar $s 9 $utf8 | Should -Be -1
+        }
+        It 'maps offset == total bytes on a multibyte string to char length (EOL boundary — the dominant accept path; > vs >= here breaks every end-of-line suggestion)' {
+            # "café" = 5 bytes, 4 chars
+            & $byteToChar "caf$eAcute" 5 $utf8 | Should -Be 4
+        }
+    }
+
+    Context '3-byte sequence (CJK)' {
+        It 'maps the boundary after one CJK char' {
+            # "中文x" = 3+3+1 bytes, 3 chars
+            & $byteToChar "$cjk${cjk}x" 3 $utf8 | Should -Be 1
+        }
+        It 'maps the boundary after two CJK chars' {
+            & $byteToChar "$cjk${cjk}x" 6 $utf8 | Should -Be 2
+        }
+        It 'rejects offsets inside a 3-byte sequence' {
+            & $byteToChar "$cjk${cjk}x" 1 $utf8 | Should -Be -1
+            & $byteToChar "$cjk${cjk}x" 2 $utf8 | Should -Be -1
+        }
+    }
+
+    Context '4-byte sequence (emoji, surrogate pair)' {
+        It 'maps the boundary after an emoji to char index 2 (one code point, two UTF-16 chars)' {
+            # "😀x" = 4+1 bytes, 3 chars
+            & $byteToChar "${emoji}x" 4 $utf8 | Should -Be 2
+        }
+        It 'rejects offsets inside the 4-byte sequence' {
+            foreach ($b in 1..3) {
+                & $byteToChar "${emoji}x" $b $utf8 | Should -Be -1
+            }
+        }
+    }
+
+    Context 'bounds and degenerate inputs' {
+        It 'rejects an offset past the end' {
+            & $byteToChar 'abc' 4 $utf8 | Should -Be -1
+        }
+        It 'rejects a negative offset' {
+            & $byteToChar 'abc' -1 $utf8 | Should -Be -1
+        }
+        It 'maps offset 0 on an empty string to 0' {
+            & $byteToChar '' 0 $utf8 | Should -Be 0
+        }
+        It 'rejects a positive offset on an empty string' {
+            & $byteToChar '' 1 $utf8 | Should -Be -1
+        }
+    }
+
+    Context 'zero-width replace range (pure insertion)' {
+        It 'converts start == end to a valid equal char pair (callers use strict < guards, which must keep allowing equality)' {
+            $start = & $byteToChar "caf$eAcute" 5 $utf8
+            $end = & $byteToChar "caf$eAcute" 5 $utf8
+            $start | Should -Be 4
+            $end | Should -Be $start
+        }
+    }
+
+    Context 'round-trip across both conversion directions' {
+        It 'byteToChar(GetByteCount(prefix)) recovers every char boundary of a mixed-width string' {
+            # "a中😀é": char boundaries 0,1,2,4,5 — index 3 is inside the surrogate pair
+            $s = "a$cjk$emoji$eAcute"
+            foreach ($i in @(0, 1, 2, 4, 5)) {
+                $b = $utf8.GetByteCount($s.Substring(0, $i))
+                & $byteToChar $s $b $utf8 | Should -Be $i
+            }
+        }
+        It 'rejects the byte offset pointing inside the surrogate pair''s 4-byte sequence' {
+            $s = "a$cjk$emoji$eAcute"
+            # bytes: a=1, 中=3, 😀=4 (bytes 4-7), é=2 -> offsets 5,6,7 are mid-emoji
+            foreach ($b in 5..7) {
+                & $byteToChar $s $b $utf8 | Should -Be -1
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The IPC protocol defines `cursor` / `replace_start` / `replace_end` as **UTF-8 byte offsets**, but the PowerShell plugin passed them to/from **UTF-16 char-indexed** .NET APIs unconverted. ASCII masks the bug (byte == char); any multibyte char in the buffer breaks it in both directions:

- **Outbound:** `cursor` was sent as a char index. Daemon tiers slice `&req.input[..req.cursor]` (`llm.rs`, `cloud.rs`, `specs.rs`) — a non-boundary index panics the tier task, so non-ASCII users got tier crashes, not just bad offsets.
- **Inbound:** `replace_start`/`replace_end` were fed raw to `Substring` and `PSConsoleReadLine::Replace`, causing off-by-N replacements or silently dropped Tab-accepts past any multibyte char (`café`, CJK, emoji).

## Fix

Conversion at the plugin boundary — the protocol and daemon stay byte-native:

- **Outbound:** send `GetByteCount($line.Substring(0, $cursor))`; the char-domain `$cursor` is untouched for the ghost-text math.
- **Inbound:** new `$byteToChar` helper (inline in the worker, like `$jsonEscape`) converts both offsets **before** the `diff_ops` branch, since both branches publish them to the accept path. Fails closed on out-of-range or mid-code-point offsets via a re-encode round-trip check plus a low-surrogate guard (covers a subtle false-pass: a truncated 4-byte emoji prefix ends in a lone high surrogate that re-encodes to a 1-byte `?`, coincidentally matching the offset).

Pure-ASCII behavior is byte-for-byte unchanged.

## Tests

- `shells/tests/converters.Tests.ps1` (Pester 5, 18 cases): ASCII identity, 2/3/4-byte sequences, mid-sequence rejection, EOL boundary (`offset == total bytes` — the dominant accept path), zero-width ranges, bounds, cross-direction round-trip. The helper is extracted via AST so none of the plugin''s side effects run under test.
- CI: Pester step on the `windows-latest` matrix leg, ahead of the cargo steps so Rust failures don''t shadow plugin results. Pester ≥5 install fallback included (runners ship 3.4 in some images).
- Manually verified: ASCII regression, `echo café build`, and `echo 中文 test` repros all accept on exact boundaries.

## Out of scope

The zsh/bash/fish plugins carry the same latent class of byte-vs-char issue in their own indexing idioms — deliberately deferred; follow-up issue to be filed for zsh after verification.

Fixes #76