### PR TITLE
fix(zsh): convert daemon byte offsets to char indices for multibyte

### DIFF
--- a/shells/nighthawk.zsh
+++ b/shells/nighthawk.zsh
@@ -66,8 +66,53 @@ _nh_log() {
 # 0x01: a literal NUL can't survive zsh command substitution, so it's unreachable.
 _nh_has_ctrl_char() { [[ "$1" == *[$'\x01'-$'\x1f\x7f']* ]] }
 
+# --- Byte offset <-> char index conversion ---
+# The daemon speaks UTF-8 BYTE offsets (replace_start/replace_end and the request
+# cursor); zsh string subscripts (${BUFFER[1,$n]}) and $CURSOR are indexed in the
+# CURRENT LOCALE's units — characters under a UTF-8 locale, raw bytes under C. These
+# helpers bridge the two. Per-char byte width comes from `LC_ALL=C ${#ch}`, scoped in an
+# anonymous function so the locale override can't leak into the rest of the call. That
+# primitive is correct in BOTH locales: under UTF-8 a char reports its true byte length;
+# under C every unit is already one byte, so both conversions collapse to the identity
+# the byte-indexed subscripts want. This is the zsh counterpart of nighthawk.ps1's
+# $byteToChar — minus its surrogate handling, since a zsh char is a whole scalar value
+# (an emoji is one char, not a UTF-16 pair).
+
+# Byte offset -> char index (count of leading subscript units). Fail-closed: returns -1
+# for a negative offset, one past the end, or one landing inside a multibyte sequence.
+_nh_byte_to_char() {
+    emulate -L zsh
+    local s=$1 boff=$2
+    (( boff < 0 )) && { print -- -1; return }
+    (( boff == 0 )) && { print -- 0; return }
+    local n=${#s} c acc=0 w
+    for (( c = 1; c <= n; c++ )); do
+        () { local LC_ALL=C; w=${#1} } "${s[c]}"
+        (( acc += w ))
+        (( acc == boff )) && { print -- $c; return }   # exact code-point boundary
+        (( acc > boff ))  && { print -- -1; return }    # offset split a multibyte char
+    done
+    print -- -1   # offset past the last byte
+}
+
+# Char index (count of leading units) -> byte offset. Clamps an over-long index to the
+# string length; its only caller passes $CURSOR, which _nh_pre_redraw has already pinned to
+# ${#BUFFER} (it bails unless CURSOR == ${#BUFFER}), so the clamp is belt-and-suspenders.
+_nh_char_to_byte() {
+    emulate -L zsh
+    local s=$1 cidx=$2
+    (( cidx <= 0 )) && { print -- 0; return }
+    (( cidx > ${#s} )) && cidx=${#s}
+    local out
+    () { local LC_ALL=C; out=${#1} } "${s[1,cidx]}"
+    print -- $out
+}
+
 # --- State ---
 typeset -g _nh_suggestion=""
+# _nh_replace_start/_end hold CHAR indices (converted from the daemon's UTF-8 byte
+# offsets in _nh_query), so the ${BUFFER[...]} subscripts in _nh_accept / _nh_render_diff
+# index correctly under a multibyte locale.
 typeset -g _nh_replace_start=""
 typeset -g _nh_replace_end=""
 typeset -g _nh_last_buffer=""
@@ -135,7 +180,8 @@ _nh_render_diff() {
     done
 
     # Replace token in BUFFER: before + diff_token + after
-    # Zsh strings are 1-indexed; replace_start/end are 0-indexed byte offsets
+    # Zsh strings are 1-indexed; token_start/replace_end are 0-indexed CHAR offsets
+    # (converted from the daemon's byte offsets in _nh_query before this is called).
     local before="${_nh_original_buffer[1,$token_start]}"
     local after="${_nh_original_buffer[$((replace_end + 1)),-1]}"
     BUFFER="${before}${new_token}${after}"
@@ -266,13 +312,20 @@ _nh_query() {
     local buffer="$1"
     local cursor="$2"
 
+    # The protocol cursor is a UTF-8 byte offset, but $CURSOR (passed in as $2) is a char
+    # index — convert before sending, mirroring nighthawk.ps1's GetByteCount. The local
+    # $cursor stays char-domain for the prefix-ghost math below. (Sending the raw char
+    # cursor would also make the daemon slice &input[..cursor] at a non-boundary byte on
+    # multibyte input.)
+    local cursor_bytes=$(_nh_char_to_byte "$buffer" "$cursor")
+
     # Escape for JSON: backslashes then double quotes
     local escaped_buffer="${buffer//\\/\\\\}"
     escaped_buffer="${escaped_buffer//\"/\\\"}"
     local escaped_cwd="${PWD//\\/\\\\}"
     escaped_cwd="${escaped_cwd//\"/\\\"}"
 
-    local json="{\"input\":\"${escaped_buffer}\",\"cursor\":${cursor},\"cwd\":\"${escaped_cwd}\",\"shell\":\"zsh\"}"
+    local json="{\"input\":\"${escaped_buffer}\",\"cursor\":${cursor_bytes},\"cwd\":\"${escaped_cwd}\",\"shell\":\"zsh\"}"
 
     _nh_log "query: buffer='$buffer' cursor=$cursor"
 
@@ -290,8 +343,8 @@ _nh_query() {
     eval $(echo "$response" | jq -r '
         if (.suggestions | length) > 0 then
             "text=" + (.suggestions[0].text | @sh) +
-            " replace_start=" + (.suggestions[0].replace_start | tostring) +
-            " replace_end=" + (.suggestions[0].replace_end | tostring) +
+            " replace_start=" + ((.suggestions[0].replace_start | tostring) | @sh) +
+            " replace_end=" + ((.suggestions[0].replace_end | tostring) | @sh) +
             " diff_ops_str=" + ((.suggestions[0].diff_ops // null) | if . then [.[] | .op[0:1] + ":" + .ch] | join(" ") | @sh else ("" | @sh) end)
         else
             "text='"''"'"
@@ -317,6 +370,25 @@ _nh_query() {
         # a phantom.
         if [[ -n "$diff_ops_str" ]] && _nh_has_ctrl_char "$diff_ops_str"; then
             _nh_log "rejected: control char in diff_ops"
+            return
+        fi
+
+        # replace_start/end are interpolated into the eval above; @sh quotes them, but
+        # still validate they're plain non-negative integers before any arithmetic — this
+        # rejects a non-numeric jq result (e.g. "null" from a malformed reply). <-> is
+        # zsh's digit glob.
+        [[ "$replace_start" == <-> && "$replace_end" == <-> ]] || return
+
+        # Protocol byte offsets -> char indices against $buffer (the exact snapshot sent
+        # in the request). Fail closed — no ghost, never corrupt the buffer — if either is
+        # out of range or lands inside a multibyte char; that can only be a daemon bug, so
+        # log it rather than silently doing nothing. From here down these locals are
+        # CHAR-domain, so the prefix math and every ${BUFFER[...]} subscript (including the
+        # _nh_render_diff call below) index correctly under a multibyte locale.
+        replace_start=$(_nh_byte_to_char "$buffer" "$replace_start")
+        replace_end=$(_nh_byte_to_char "$buffer" "$replace_end")
+        if (( replace_start < 0 || replace_end < 0 || replace_end < replace_start )); then
+            _nh_log "rejected: replace range not on a code-point boundary"
             return
         fi
 
@@ -404,6 +476,19 @@ _nh_accept() {
         _nh_has_highlight=0
         _nh_suggestion=""
         _nh_diff_ops=""
+
+        # Defensive bounds check. rstart/rend are char offsets captured at query time
+        # against the original buffer, which we just restored above, so they can't drift in
+        # today's synchronous path (any edit clears them via _nh_restore_before_edit). But
+        # an out-of-range zsh subscript fails SILENTLY (yields empty rather than erroring),
+        # so guard explicitly — this is also the seam where async IPC will need it.
+        if (( rstart < 0 || rend < rstart || rend > ${#BUFFER} )); then
+            _nh_log "accept: stale/out-of-range range [$rstart,$rend) for buffer len ${#BUFFER}"
+            _nh_replace_start=""
+            _nh_replace_end=""
+            _nh_last_buffer="$BUFFER"
+            return
+        fi
 
         # Replace the token: BUFFER[0..rstart] + suggestion + BUFFER[rend..]
         # Zsh strings are 1-indexed

--- a/shells/tests/offsets.test.zsh
+++ b/shells/tests/offsets.test.zsh
@@ -1,0 +1,116 @@
+#!/usr/bin/env zsh
+# Unit tests for the _nh_byte_to_char / _nh_char_to_byte helpers in shells/nighthawk.zsh
+# (issue: the daemon speaks UTF-8 BYTE offsets, zsh subscripts index in locale units —
+# characters under a UTF-8 locale — so accept mis-replaces on CJK/emoji without conversion).
+#
+# Hermetic by sourcing the plugin with the interactive ZLE builtins (zle/bindkey) stubbed
+# to no-ops and config isolated to a temp dir, so none of the plugin's side effects (widget
+# registration, keymap binding, user config) run. This is the zsh analogue of how
+# shells/tests/converters.Tests.ps1 AST-extracts just the PowerShell $byteToChar.
+#
+# Requires the same tools the plugin does (zsh, socat, jq on PATH); if they're missing the
+# plugin returns early and the helpers won't be defined — caught below as a loud failure.
+#
+# Run:  zsh shells/tests/offsets.test.zsh
+emulate -L zsh
+
+# --- Hermetic source ---
+# Shadow the ZLE builtins so `zle -N` / `bindkey` registration is inert during sourcing.
+zle()     { : }
+bindkey() { : }
+
+_nh_tmpcfg=$(mktemp -d)
+export XDG_CONFIG_HOME=$_nh_tmpcfg
+_nh_plugin="${0:A:h}/../nighthawk.zsh"
+if [[ ! -r "$_nh_plugin" ]]; then
+    print -u2 "offsets.test.zsh: cannot read $_nh_plugin"
+    rm -rf "$_nh_tmpcfg"
+    exit 2
+fi
+source "$_nh_plugin"
+rm -rf "$_nh_tmpcfg"
+
+# Structural check: the helpers must exist (guards against a rename, like the PS test's
+# "was it renamed?" throw — the sourcing above is the precondition that makes this sound).
+if (( ! $+functions[_nh_byte_to_char] || ! $+functions[_nh_char_to_byte] )); then
+    print -u2 "offsets.test.zsh: FAIL — offset helpers not defined after sourcing plugin (renamed? deps missing?)"
+    exit 2
+fi
+
+# --- Assertion harness ---
+typeset -gi _nh_pass=0 _nh_fail=0
+check() {  # check <desc> <expected> <actual>
+    if [[ "$2" == "$3" ]]; then
+        (( _nh_pass++ ))
+    else
+        (( _nh_fail++ ))
+        print -r -- "FAIL: $1 — expected '$2' got '$3'"
+    fi
+}
+
+# Test data built from CODE POINTS, not literal glyphs, so it survives file-encoding
+# mishaps regardless of how the file is checked out (matching converters.Tests.ps1's
+# rationale). Widths: a=1B  U+00E9(e-acute)=2B  U+4E2D(CJK)=3B  U+1F600(emoji)=4B  U+00E9=2B
+#   => byte boundaries 0,1,3,6,10,12 ; 5 char units.
+S=$'\u0061\u00e9\u4e2d\U0001f600\u00e9'
+
+# --- ASCII (byte == char identity) ---
+A="git checkout"
+check "ascii b2c 0"        0  "$(_nh_byte_to_char "$A" 0)"
+check "ascii b2c 4"        4  "$(_nh_byte_to_char "$A" 4)"
+check "ascii b2c 12 (EOL)" 12 "$(_nh_byte_to_char "$A" 12)"
+check "ascii c2b 4"        4  "$(_nh_char_to_byte "$A" 4)"
+check "ascii c2b 12 (EOL)" 12 "$(_nh_char_to_byte "$A" 12)"
+
+# --- byte_to_char on code-point boundaries (2/3/4-byte sequences, each -> one char) ---
+check "b2c 0"             0 "$(_nh_byte_to_char "$S" 0)"
+check "b2c 1 (after 1B)"  1 "$(_nh_byte_to_char "$S" 1)"
+check "b2c 3 (after 2B)"  2 "$(_nh_byte_to_char "$S" 3)"
+check "b2c 6 (after 3B)"  3 "$(_nh_byte_to_char "$S" 6)"
+check "b2c 10 (after 4B)" 4 "$(_nh_byte_to_char "$S" 10)"
+check "b2c 12 (EOL)"      5 "$(_nh_byte_to_char "$S" 12)"
+
+# --- mid-sequence rejections (fail-closed -> -1) ---
+check "b2c 2  (mid 2-byte seq)" -1 "$(_nh_byte_to_char "$S" 2)"
+check "b2c 4  (mid 3-byte seq)" -1 "$(_nh_byte_to_char "$S" 4)"
+check "b2c 5  (mid 3-byte seq)" -1 "$(_nh_byte_to_char "$S" 5)"
+check "b2c 7  (mid 4-byte seq)" -1 "$(_nh_byte_to_char "$S" 7)"
+check "b2c 8  (mid 4-byte seq)" -1 "$(_nh_byte_to_char "$S" 8)"
+check "b2c 9  (mid 4-byte seq)" -1 "$(_nh_byte_to_char "$S" 9)"
+
+# --- bounds & degenerate inputs ---
+check "b2c -1 (negative)"    -1 "$(_nh_byte_to_char "$S" -1)"
+check "b2c 13 (past end)"    -1 "$(_nh_byte_to_char "$S" 13)"
+check "b2c empty, off 0"      0 "$(_nh_byte_to_char "" 0)"
+check "b2c empty, off 1"     -1 "$(_nh_byte_to_char "" 1)"
+
+# --- char_to_byte inverse on boundaries ---
+check "c2b 0"  0  "$(_nh_char_to_byte "$S" 0)"
+check "c2b 1"  1  "$(_nh_char_to_byte "$S" 1)"
+check "c2b 2"  3  "$(_nh_char_to_byte "$S" 2)"
+check "c2b 3"  6  "$(_nh_char_to_byte "$S" 3)"
+check "c2b 4"  10 "$(_nh_char_to_byte "$S" 4)"
+check "c2b 5"  12 "$(_nh_char_to_byte "$S" 5)"
+check "c2b past-end clamps" 12 "$(_nh_char_to_byte "$S" 99)"
+check "c2b negative -> 0"    0 "$(_nh_char_to_byte "$S" -3)"
+
+# --- round-trip: byte_to_char(char_to_byte(i)) == i over every boundary ---
+local i b
+for i in 0 1 2 3 4 5; do
+    b=$(_nh_char_to_byte "$S" $i)
+    check "roundtrip char $i (byte $b)" $i "$(_nh_byte_to_char "$S" $b)"
+done
+
+# --- multi-codepoint ZWJ grapheme: each code point is a separate zsh char; the
+# per-code-point walk must round-trip just like single-code-point chars (locks the
+# contract that we count UTF-8 bytes per code point, matching the byte-native daemon).
+# U+1F468 ZWJ(U+200D) U+1F469 ZWJ U+1F467 = man/woman/girl family = 5 code points. ---
+local FAM=$'\U0001f468\u200d\U0001f469\u200d\U0001f467'
+for (( i = 0; i <= ${#FAM}; i++ )); do
+    b=$(_nh_char_to_byte "$FAM" $i)
+    check "ZWJ roundtrip char $i (byte $b)" $i "$(_nh_byte_to_char "$FAM" $b)"
+done
+
+# --- summary ---
+print -r -- "offsets.test.zsh: $_nh_pass passed, $_nh_fail failed"
+(( _nh_fail == 0 ))


### PR DESCRIPTION
The daemon emits UTF-8 **byte** offsets in `replace_start`/`replace_end`, but the zsh plugin used them directly as ZLE **character** indices. For any buffer containing multibyte text (accents, CJK, emoji) before the cursor, the replace range was wrong — ghost text rendered at the wrong column and Tab-accept spliced at the wrong offset.

## Fix
- Add `_nh_byte_to_char` / `_nh_char_to_byte` helpers (per-char width via a scoped `() { local LC_ALL=C; ... }` so it is correct under both UTF-8 and C locales; one zsh char = one scalar, no surrogate handling needed).
- Convert the cursor char→byte on the request, and convert the response offsets byte→char **once** in `_nh_query`, reassigning the locals so all downstream consumers (`_nh_accept`, `_nh_render_diff`, prefix-ghost) operate purely in the char domain.
- Fail closed on out-of-range / mid-codepoint offsets.
- Harden the `jq` eval: `@sh`-quote the two offset fields and numeric-guard them (`[[ "$replace_start" == <-> && ... ]]`).

## Tests
`shells/tests/offsets.test.zsh` — 41 assertions, sources the plugin with `zle`/`bindkey` stubbed and an isolated `XDG_CONFIG_HOME`. Uses `$'é...'` literals for encoding immunity. Pure-logic offset functions are now unit-tested; render/accept ZLE behavior still needs manual/zpty testing.

Closes #80