### PR TITLE
fix(daemon): sanitize out-of-bounds/non-boundary cursor before tier slicing

### DIFF
--- a/src/daemon/engine/mod.rs
+++ b/src/daemon/engine/mod.rs
@@ -26,6 +26,28 @@ impl PredictionEngine {
 
     /// Run the prediction cascade and return the best suggestions.
     pub async fn complete(&self, req: &CompletionRequest) -> CompletionResponse {
+        // Every tier slices `&req.input[..req.cursor]`, which PANICS if `cursor` is past
+        // the end or not on a UTF-8 char boundary — e.g. a client that sends a character
+        // index where the protocol wants a byte offset (the pre-fix zsh/bash plugins did
+        // exactly this, crashing a worker on any multibyte input). Sanitize once here, at
+        // the single entry point, by snapping the cursor down to the nearest valid
+        // boundary; the clone only happens on the rare bad-cursor path.
+        let sanitized;
+        let req = if req.cursor > req.input.len() || !req.input.is_char_boundary(req.cursor) {
+            let mut c = req.cursor.min(req.input.len());
+            while c > 0 && !req.input.is_char_boundary(c) {
+                c -= 1;
+            }
+            debug!(from = req.cursor, to = c, "Sanitized out-of-bounds cursor");
+            sanitized = CompletionRequest {
+                cursor: c,
+                ..req.clone()
+            };
+            &sanitized
+        } else {
+            req
+        };
+
         for tier in &self.tiers {
             match tokio::time::timeout(
                 std::time::Duration::from_millis(tier.budget_ms() as u64 + 50),
@@ -151,5 +173,70 @@ mod tests {
         let engine = PredictionEngine::new(vec![Box::new(empty_tier), Box::new(real_tier)]);
         let resp = engine.complete(&test_request()).await;
         assert_eq!(resp.suggestions[0].text, "cherry-pick");
+    }
+
+    /// Tier that slices `&req.input[..req.cursor]` exactly as the real tiers do (history,
+    /// specs, cloud, llm all open with that line) and echoes the cursor it actually saw.
+    /// If the engine fails to sanitize a bad cursor, the slice here panics — that's the
+    /// regression these tests guard.
+    struct EchoCursorTier;
+
+    #[async_trait]
+    impl PredictionTier for EchoCursorTier {
+        fn name(&self) -> &str {
+            "echo-cursor"
+        }
+        fn budget_ms(&self) -> u32 {
+            10
+        }
+        async fn predict(&self, req: &CompletionRequest) -> Vec<Suggestion> {
+            let prefix = &req.input[..req.cursor];
+            vec![Suggestion {
+                text: format!("cursor={} prefix={}", req.cursor, prefix),
+                replace_start: req.cursor,
+                replace_end: req.cursor,
+                confidence: 1.0,
+                source: SuggestionSource::History,
+                description: None,
+                diff_ops: None,
+            }]
+        }
+    }
+
+    #[tokio::test]
+    async fn sanitizes_cursor_inside_multibyte_char() {
+        // "café": é occupies bytes 3-4, so byte 4 is INSIDE the 2-byte sequence (not a
+        // char boundary). The pre-fix code panicked here on every multibyte buffer.
+        let req = CompletionRequest {
+            input: "café".into(),
+            cursor: 4,
+            cwd: PathBuf::from("/tmp"),
+            shell: Shell::Zsh,
+        };
+        let engine = PredictionEngine::new(vec![Box::new(EchoCursorTier)]);
+        let resp = engine.complete(&req).await; // must not panic
+                                                // Snapped down to the boundary before é.
+        assert_eq!(resp.suggestions[0].text, "cursor=3 prefix=caf");
+    }
+
+    #[tokio::test]
+    async fn sanitizes_cursor_past_end() {
+        let req = CompletionRequest {
+            input: "git".into(),
+            cursor: 99,
+            cwd: PathBuf::from("/tmp"),
+            shell: Shell::Zsh,
+        };
+        let engine = PredictionEngine::new(vec![Box::new(EchoCursorTier)]);
+        let resp = engine.complete(&req).await; // must not panic
+        assert_eq!(resp.suggestions[0].text, "cursor=3 prefix=git");
+    }
+
+    #[tokio::test]
+    async fn valid_cursor_is_unchanged() {
+        // "git ch" len 6, cursor 6 is a valid boundary — must pass through untouched.
+        let engine = PredictionEngine::new(vec![Box::new(EchoCursorTier)]);
+        let resp = engine.complete(&test_request()).await;
+        assert_eq!(resp.suggestions[0].text, "cursor=6 prefix=git ch");
     }
 }


### PR DESCRIPTION
Several tiers slice `&req.input[..req.cursor]` to get the text before the cursor. If a client ever sends a `cursor` that is past the end of `input` or lands **mid-UTF-8-codepoint**, that slice panics — and a panic in the daemon takes down the IPC server for all clients.

## Fix
Add a single central guard in `PredictionEngine::complete()` that snaps a past-end or non-boundary cursor **down** to the nearest UTF-8 char boundary **before** any tier runs. One guard covers every tier (history, specs, cloud, both llm) instead of each tier defending itself.

## Tests
3 regression tests via an `EchoCursorTier` (past-end cursor, mid-codepoint cursor, valid cursor unchanged). 85 engine tests pass.

Surfaced while manually testing multibyte handling in the zsh plugin. Independent of the zsh offset fix (#80) and the metafied-history fix (#79).