### PR TITLE
feat(zsh): async IPC off the keystroke thread (zle -F)

### DIFF
--- a/shells/nighthawk.zsh
+++ b/shells/nighthawk.zsh
@@ -53,6 +53,15 @@ if [[ -n "$NIGHTHAWK_DEBUG" ]]; then
     [[ "$NIGHTHAWK_DEBUG" == "1" ]] && _nh_debug=1 || _nh_debug=0
 fi
 
+# Validate debounce_ms before it ever reaches arithmetic. The config regex above only accepts
+# digits, but the env override is unguarded — a stray NIGHTHAWK_DEBOUNCE_MS=foo would otherwise
+# throw "bad math expression" from inside the keystroke path when we divide. Clamp to the default.
+# (<-> is zsh's digit glob.)
+[[ "$_nh_debounce_ms" == <-> ]] || _nh_debounce_ms=200
+# Debounce interval in seconds for the `sleep`-based timer. Float; GNU/BSD sleep accept it, the
+# same assumption the existing `sleep 0.2` auto-start path already makes.
+typeset -gF _nh_debounce_sec=$(( _nh_debounce_ms / 1000.0 ))
+
 # --- Diagnostic logging ---
 # No-op unless debug is on. Millisecond timestamps via GNU date's %N (present on
 # Linux/WSL); harmless cosmetic degradation elsewhere.
@@ -109,6 +118,21 @@ _nh_char_to_byte() {
 }
 
 # --- State ---
+# Re-source teardown. zsh keeps `zle -F` fd registrations AND open fds across a re-source, so a
+# prior load may have left a debounce/response watcher live; left alone it fires forever on its
+# sleep-EOF into stale handlers and leaks the fd. Tear them down using the PREVIOUS load's saved
+# fd numbers before the typesets below reset the vars. (Analogue of nighthawk.ps1's
+# subscriber/timer/pool teardown at the top of its re-source path.) Unregister before close.
+() {
+    emulate -L zsh
+    local fd
+    for fd in "$_nh_debounce_fd" "$_nh_resp_fd"; do
+        [[ -n "$fd" && "$fd" != 0 ]] || continue
+        zle -F "$fd" 2>/dev/null
+        exec {fd}<&- 2>/dev/null
+    done
+}
+
 typeset -g _nh_suggestion=""
 # _nh_replace_start/_end hold CHAR indices (converted from the daemon's UTF-8 byte
 # offsets in _nh_query), so the ${BUFFER[...]} subscripts in _nh_accept / _nh_render_diff
@@ -121,6 +145,15 @@ typeset -g _nh_diff_ops=""
 typeset -g _nh_original_buffer=""
 typeset -g _nh_original_cursor=""
 typeset -g _nh_backoff_until=0
+# Async IPC state (see the "Daemon communication (async)" section below).
+typeset -g _nh_debounce_fd=0       # fd of the in-flight debounce `sleep` timer (0 = none)
+typeset -g _nh_resp_fd=0           # fd of the in-flight socat response stream (0 = none)
+typeset -g _nh_gen=0               # monotonic generation, bumped on every cancel / new query
+typeset -g _nh_dispatch_gen=0      # generation captured when the current request was dispatched
+typeset -g _nh_inflight_buffer=""  # $BUFFER snapshot the in-flight request is about
+typeset -g _nh_inflight_cursor=""  # $CURSOR snapshot (char domain) at dispatch time
+typeset -g _nh_resp_accum=""       # partial-read accumulator for the response line
+typeset -g _nh_pending_response="" # complete reply line, handed from fd handler to render widget
 
 # --- Dependency check ---
 if ! command -v socat &>/dev/null; then
@@ -131,6 +164,10 @@ if ! command -v jq &>/dev/null; then
     echo "nighthawk: jq not found, install with: apt install jq" >&2
     return 1
 fi
+
+# zsh/system provides `sysread`, the non-blocking fd drain used by the async response handler.
+# It's a standard built-in module that ships with zsh, so this is not a new external dependency.
+zmodload zsh/system 2>/dev/null
 
 # --- Ghost text rendering via POSTDISPLAY ---
 _nh_render_ghost() {
@@ -250,6 +287,12 @@ _nh_backward_kill_word() {
 zle -N backward-kill-word _nh_backward_kill_word
 
 _nh_clear_ghost() {
+    # Cancel any pending debounce timer / in-flight request so a now-stale reply can't paint a
+    # phantom ghost after the buffer moved on. This is the zsh analogue of nighthawk.ps1's
+    # _nh_clear_ghost stopping the timer + bumping generation. Also covers the Escape path, which
+    # routes through here. (Re-armed by the next keystroke's _nh_schedule_query.)
+    _nh_cancel_inflight
+
     # Clear any ghost we rendered. POSTDISPLAY and region_highlight are ZLE-managed:
     # unsetting them and letting ZLE repaint clears the ghost — including wrapped
     # lines, whose row count ZLE already tracks. Do NOT emit raw clear escapes here.
@@ -299,24 +342,105 @@ _nh_ensure_daemon() {
     return 0
 }
 
-# --- Daemon communication ---
-_nh_query() {
-    # Back off for 5s after connection failure so dead daemon doesn't block every keystroke
-    local now=$EPOCHSECONDS
-    if (( now < _nh_backoff_until )); then
-        return
+# --- Daemon communication (async) ---
+# Split across the keystroke and the eventual reply so IPC never blocks the input loop
+# (CLAUDE.md: "Never block the input loop in shell plugins"). zsh has no threads, so the async
+# seam is the socket fd: `zle -F <fd> <handler>` makes ZLE call us back when a descriptor is
+# readable. Flow per query:
+#   keystroke -> _nh_schedule_query   arm a debounce timer (a `sleep` whose EOF fires us)
+#             -> _nh_debounce_fire     timer elapsed -> actually send the request
+#             -> _nh_dispatch          spawn socat, register the response fd
+#             -> _nh_on_response        fd readable -> drain (non-blocking), staleness-gate
+#             -> _nh_handle_response    parse + validate + render (the old synchronous body)
+# This mirrors nighthawk.ps1's debounce-timer -> runspace-worker. PowerShell needs a synchronized
+# hashtable + generation counter to coordinate REAL threads; our callbacks run on the same thread
+# as keystrokes, so a buffer snapshot is itself a sound staleness signal and the generation
+# counter is kept only as defense-in-depth.
+
+# Tear down a pending debounce timer and/or in-flight request, and bump the generation so any
+# reply still in flight is treated as stale. Idempotent — every teardown path calls it. Unregister
+# BEFORE close (a closed fd number may already be recycled, so a late unregister could hit the
+# wrong watcher), and null the handle after so a double-cancel can't close a descriptor zsh has
+# since handed to something else.
+_nh_cancel_inflight() {
+    emulate -L zsh
+    (( _nh_gen++ ))
+    local fd
+    if [[ -n "$_nh_debounce_fd" && "$_nh_debounce_fd" != 0 ]]; then
+        fd=$_nh_debounce_fd
+        zle -F "$fd" 2>/dev/null
+        exec {fd}<&- 2>/dev/null
+        _nh_debounce_fd=0
     fi
+    if [[ -n "$_nh_resp_fd" && "$_nh_resp_fd" != 0 ]]; then
+        fd=$_nh_resp_fd
+        zle -F "$fd" 2>/dev/null
+        exec {fd}<&- 2>/dev/null
+        _nh_resp_fd=0
+    fi
+    _nh_resp_accum=""
+}
+
+# A reply is fresh iff nothing superseded the request since dispatch. The generation counter is the
+# whole signal: every cancel / new query bumps _nh_gen (via _nh_cancel_inflight) and re-stamps
+# _nh_dispatch_gen, so a reply is current exactly when the two are still equal. Because these
+# callbacks run on the SAME thread as keystrokes (they can't interleave), the generation can't drift
+# under us mid-check — there's no ABA race to defend against. We deliberately do NOT compare against
+# live $BUFFER/$CURSOR here: inside a `zle -F` fd-handler callback those special parameters are NOT
+# bound to the line editor (they read back empty), so a buffer/cursor compare would reject every
+# reply. The dispatch snapshot ($_nh_inflight_buffer/_cursor) is what the render path uses instead.
+# Factored out so the async path is unit-testable without a live fd.
+_nh_reply_is_fresh() {
+    (( _nh_gen == _nh_dispatch_gen ))
+}
+
+# Keystroke entry point: arm the debounce timer.
+_nh_schedule_query() {
+    emulate -L zsh
+    # Back off after a connection failure so a dead daemon doesn't arm a timer every keystroke.
+    (( EPOCHSECONDS < _nh_backoff_until )) && return
 
     _nh_ensure_daemon
 
-    local buffer="$1"
-    local cursor="$2"
+    # Cancel any prior timer/request (also bumps the generation), then snapshot the buffer this
+    # query is about. The snapshot is both the staleness key and the exact string the daemon's
+    # byte offsets are resolved against in _nh_handle_response.
+    _nh_cancel_inflight
+    _nh_inflight_buffer="$BUFFER"
+    _nh_inflight_cursor="$CURSOR"
+    _nh_dispatch_gen=$_nh_gen
 
-    # The protocol cursor is a UTF-8 byte offset, but $CURSOR (passed in as $2) is a char
-    # index — convert before sending, mirroring nighthawk.ps1's GetByteCount. The local
-    # $cursor stays char-domain for the prefix-ghost math below. (Sending the raw char
-    # cursor would also make the daemon slice &input[..cursor] at a non-boundary byte on
-    # multibyte input.)
+    # The debounce timer is a `sleep` subprocess; its EOF (process exit) makes the fd readable and
+    # fires _nh_debounce_fire. If the user types again first, _nh_cancel_inflight closes this fd
+    # before the sleep ends so the request is never sent — coalescing keystrokes is the whole point
+    # of debounce, and keeping the sleep SEPARATE from socat is what lets us cancel before paying
+    # for a daemon round-trip (vs. folding `sleep; socat` into one child, which would query on every
+    # keystroke unless we tracked and killed its PID).
+    local fd
+    exec {fd}< <(sleep $_nh_debounce_sec) || return
+    _nh_debounce_fd=$fd
+    zle -F "$fd" _nh_debounce_fire
+}
+
+# Debounce elapsed: disarm the timer fd and send the request.
+_nh_debounce_fire() {
+    emulate -L zsh
+    local fd=$1
+    zle -F "$fd" 2>/dev/null
+    exec {fd}<&- 2>/dev/null
+    _nh_debounce_fd=0
+    _nh_dispatch
+}
+
+# Build the request from the snapshot and spawn the non-blocking socat read.
+_nh_dispatch() {
+    emulate -L zsh
+    local buffer="$_nh_inflight_buffer"
+    local cursor="$_nh_inflight_cursor"
+
+    # The protocol cursor is a UTF-8 byte offset, but the snapshot $cursor is a char index —
+    # convert before sending, mirroring nighthawk.ps1's GetByteCount. (Sending the raw char cursor
+    # would also make the daemon slice &input[..cursor] at a non-boundary byte on multibyte input.)
     local cursor_bytes=$(_nh_char_to_byte "$buffer" "$cursor")
 
     # Escape for JSON: backslashes then double quotes
@@ -327,16 +451,95 @@ _nh_query() {
 
     local json="{\"input\":\"${escaped_buffer}\",\"cursor\":${cursor_bytes},\"cwd\":\"${escaped_cwd}\",\"shell\":\"zsh\"}"
 
-    _nh_log "query: buffer='$buffer' cursor=$cursor"
+    _nh_log "dispatch: buffer='$buffer' cursor=$cursor gen=$_nh_dispatch_gen"
 
-    local response
-    response=$(echo "$json" | socat -t1 - UNIX-CONNECT:"$NIGHTHAWK_SOCKET" 2>/dev/null)
+    # socat writes the daemon's reply to this fd and exits; ZLE calls _nh_on_response when it's
+    # readable. -t3 keeps socat's inactivity timeout above the cloud tier's 2000ms budget (+slack)
+    # so a slow-but-valid LLM reply isn't cut off and mis-read as a dead daemon — the zsh
+    # counterpart of nighthawk.ps1's 2250ms read timeout.
+    local fd
+    exec {fd}< <(print -r -- "$json" | socat -t3 - UNIX-CONNECT:"$NIGHTHAWK_SOCKET" 2>/dev/null) || return
+    _nh_resp_fd=$fd
+    _nh_resp_accum=""
+    zle -F "$fd" _nh_on_response
+}
+
+# Response fd readable: drain without blocking, gate on freshness, hand off to render.
+_nh_on_response() {
+    emulate -L zsh
+    local fd=$1 reason=$2 chunk
+
+    # Drain everything available now. `sysread -t 0` returns 0 on bytes, 4 on would-block (no more
+    # yet — stay registered for the next callback), 5/other on EOF/error. The terminating status
+    # MUST be captured INSIDE the loop: a zsh `while` exits with its body's status (here the
+    # successful `+=` append => 0), so reading $? after the loop would always see 0 and we'd treat a
+    # mid-stream partial as a complete reply and truncate multi-chunk responses. Likewise the var is
+    # `sr_status`, never `status` — `status` is a read-only alias for $? in zsh and `local status`
+    # would abort this handler on every reply.
+    local sr_status=4
+    while :; do
+        sysread -i "$fd" -t 0 chunk 2>/dev/null
+        sr_status=$?
+        (( sr_status == 0 )) || break
+        _nh_resp_accum+="$chunk"
+    done
+
+    # Finished iff a full line is buffered, OR the stream ended (sysread EOF/error => status != 4,
+    # or ZLE reported the fd hung up via a non-empty reason). Until then, wait for the next callback.
+    local done=0
+    [[ "$_nh_resp_accum" == *$'\n'* ]] && done=1
+    (( sr_status != 4 )) && done=1
+    [[ -n "$reason" ]] && done=1
+    (( done )) || return
+
+    # Tear down the fd up front so every early return in _nh_handle_response below is leak-free.
+    zle -F "$fd" 2>/dev/null
+    exec {fd}<&- 2>/dev/null
+    _nh_resp_fd=0
+
+    local response="${_nh_resp_accum%%$'\n'*}"   # first complete line only
+    _nh_resp_accum=""
 
     if [[ -z "$response" ]]; then
         _nh_log "no response, backing off 5s"
         _nh_backoff_until=$(( EPOCHSECONDS + 5 ))
         return
     fi
+
+    if ! _nh_reply_is_fresh; then
+        _nh_log "stale reply dropped (gen $_nh_dispatch_gen vs $_nh_gen)"
+        return
+    fi
+
+    # We CANNOT render from here. A `zle -F` fd-handler runs OUTSIDE the line-editor widget context:
+    # $BUFFER/$CURSOR/$POSTDISPLAY/region_highlight are not bound to the live editor ($BUFFER reads
+    # back empty), and a direct `zle -R` from here paints nothing. Stash the reply and bounce into a
+    # real widget — `zle <widget>` re-enters proper editor context where those parameters ARE live
+    # and the display actually updates. (Verified empirically; this is the crux of the async design.)
+    _nh_pending_response="$response"
+    zle _nh_apply_response
+    zle -R
+}
+
+# Real ZLE widget that performs the render. Unlike _nh_on_response (an fd handler), this runs in
+# editor context, so $BUFFER/$CURSOR/$POSTDISPLAY are live and the render helpers paint correctly.
+# Invoked via `zle _nh_apply_response` from the fd handler once a complete, fresh reply is buffered.
+_nh_apply_response() {
+    emulate -L zsh
+    _nh_handle_response "$_nh_pending_response"
+    _nh_pending_response=""
+}
+zle -N _nh_apply_response
+
+# Parse + validate + render the daemon's reply against the dispatch snapshot. This is the old
+# synchronous _nh_query body from "parse first suggestion" onward, moved verbatim and retargeted to
+# the snapshot ($_nh_inflight_buffer/_cursor) instead of live $BUFFER/$CURSOR. Kept as its own
+# function so the async path can be unit-tested by calling it with a canned response.
+_nh_handle_response() {
+    emulate -L zsh
+    local response="$1"
+    local buffer="$_nh_inflight_buffer"
+    local cursor="$_nh_inflight_cursor"
 
     # Parse first suggestion (text, replace range, and diff_ops if present)
     local text replace_start replace_end diff_ops_str
@@ -449,13 +652,17 @@ _nh_pre_redraw() {
     # Need at least 2 chars
     (( ${#BUFFER} < 2 )) && return
 
-    _nh_query "$BUFFER" "$CURSOR"
+    # Arm the debounce timer; the actual IPC happens off the keystroke thread (see _nh_schedule_query).
+    _nh_schedule_query
 }
 
 zle -N zle-line-pre-redraw _nh_pre_redraw
 
 # --- Accept suggestion ---
 _nh_accept() {
+    # Cancel any pending debounce/in-flight request so a reply arriving after we accept can't
+    # repaint a ghost over the committed line (this path doesn't route through _nh_clear_ghost).
+    _nh_cancel_inflight
     if [[ -n "$_nh_suggestion" && "$_nh_replace_start" != "" && "$_nh_replace_end" != "" ]]; then
         local suggestion="$_nh_suggestion"
         local rstart="$_nh_replace_start"
@@ -512,6 +719,12 @@ bindkey '^I' _nh_accept
 
 # --- Clean up on line accept (Enter) ---
 _nh_line_finish() {
+    # Cancel any pending debounce/in-flight request BEFORE accept-line, so a reply that lands
+    # during the transition can't paint a ghost fragment onto the next prompt. Closing the fd
+    # here means a queued callback fires on a closed descriptor (no-op) and the empty next-prompt
+    # buffer would fail the staleness gate anyway — belt and suspenders.
+    _nh_cancel_inflight
+
     # Restore original buffer if diff rendering modified it,
     # so the shell executes what the user actually typed
     if [[ -n "$_nh_original_buffer" ]]; then

--- a/shells/nighthawk.zsh
+++ b/shells/nighthawk.zsh
@@ -11,8 +11,8 @@ NIGHTHAWK_FUZZY_DISPLAY="${NIGHTHAWK_FUZZY_DISPLAY:-hint}"
 # Plugin settings: the [plugin] section of config.toml, with env-var overrides
 # (precedence env > file > default), mirroring the PowerShell plugin's keys and
 # precedence. The default arrow differs by design — zsh keeps the Unicode "→",
-# PowerShell uses ASCII "->". debounce_ms is parsed but not yet consumed: the zsh
-# query path is still synchronous, so it will be wired when async IPC lands.
+# PowerShell uses ASCII "->". debounce_ms drives the async query path: it is converted
+# to _nh_debounce_sec below and used to arm the debounce timer in _nh_schedule_query.
 typeset -g _nh_hint_arrow="→"
 typeset -g _nh_debug=0
 typeset -g _nh_debounce_ms=200
@@ -135,8 +135,8 @@ _nh_char_to_byte() {
 
 typeset -g _nh_suggestion=""
 # _nh_replace_start/_end hold CHAR indices (converted from the daemon's UTF-8 byte
-# offsets in _nh_query), so the ${BUFFER[...]} subscripts in _nh_accept / _nh_render_diff
-# index correctly under a multibyte locale.
+# offsets in _nh_handle_response), so the ${BUFFER[...]} subscripts in _nh_accept /
+# _nh_render_diff index correctly under a multibyte locale.
 typeset -g _nh_replace_start=""
 typeset -g _nh_replace_end=""
 typeset -g _nh_last_buffer=""
@@ -218,7 +218,7 @@ _nh_render_diff() {
 
     # Replace token in BUFFER: before + diff_token + after
     # Zsh strings are 1-indexed; token_start/replace_end are 0-indexed CHAR offsets
-    # (converted from the daemon's byte offsets in _nh_query before this is called).
+    # (converted from the daemon's byte offsets in _nh_handle_response before this is called).
     local before="${_nh_original_buffer[1,$token_start]}"
     local after="${_nh_original_buffer[$((replace_end + 1)),-1]}"
     BUFFER="${before}${new_token}${after}"
@@ -531,10 +531,10 @@ _nh_apply_response() {
 }
 zle -N _nh_apply_response
 
-# Parse + validate + render the daemon's reply against the dispatch snapshot. This is the old
-# synchronous _nh_query body from "parse first suggestion" onward, moved verbatim and retargeted to
-# the snapshot ($_nh_inflight_buffer/_cursor) instead of live $BUFFER/$CURSOR. Kept as its own
-# function so the async path can be unit-tested by calling it with a canned response.
+# Parse + validate + render the daemon's reply against the dispatch snapshot. This is the parse +
+# render body that was synchronous before the async rewrite, now retargeted to the snapshot
+# ($_nh_inflight_buffer/_cursor) instead of live $BUFFER/$CURSOR. Kept as its own function so the
+# async path can be unit-tested by calling it with a canned response.
 _nh_handle_response() {
     emulate -L zsh
     local response="$1"

--- a/shells/tests/async.test.zsh
+++ b/shells/tests/async.test.zsh
@@ -1,0 +1,244 @@
+#!/usr/bin/env zsh
+# Unit tests for the async IPC response path in shells/nighthawk.zsh.
+#
+# The async rewrite moved the synchronous query body into two testable seams:
+#   _nh_handle_response <json>  — parse + validate + render a daemon reply against the snapshot
+#   _nh_reply_is_fresh          — the staleness gate (generation counter only; see note below)
+#
+# Freshness is generation-only: a `zle -F` fd-handler runs OUTSIDE editor context, so $BUFFER/$CURSOR
+# read back empty there — a buffer/cursor compare would reject every reply. The generation counter
+# (bumped by every cancel / new query, on the same thread as keystrokes) is the complete signal.
+# Both are pure functions of globals we can set directly, so we exercise them WITHOUT a live fd,
+# a real daemon, or ZLE — the same hermetic approach as offsets.test.zsh (which AST-isolates the
+# byte/char helpers). The live fd plumbing (zle -F, the sleep-timer, socat) is covered by manual
+# testing in a real zsh session, per project convention.
+#
+# Control-char note: JSON forbids raw 0x00-0x1f, and zsh `echo` (in the plugin's `echo|jq`
+# pipeline) interprets backslash escapes — so a  on the wire is rejected at the jq-parse
+# layer. 0x7f (DEL) is the one control char JSON allows RAW, so it survives jq and is what lets us
+# drive _nh_has_ctrl_char end-to-end below.
+#
+# Requires zsh, socat, jq on PATH (the plugin returns early without socat/jq, so the functions
+# wouldn't be defined — caught below as a loud failure).
+#
+# Run:  zsh shells/tests/async.test.zsh
+emulate -L zsh
+
+# --- Hermetic source ---
+# Shadow the interactive ZLE builtins so widget/keymap registration is inert during sourcing, and
+# isolate config to a temp dir. We also set NIGHTHAWK_DEBOUNCE_MS to a non-numeric value up front
+# to exercise the load-time validation (asserted at the end).
+#
+# The `zle` stub is inert for every flag form (-N/-F/-A/-R/-l registration and repaint), but when
+# the plugin invokes a widget BY NAME (`zle _nh_apply_response`) it dispatches to the real function.
+# That's deliberate: the live render path is fd-handler -> `zle <widget>` -> render (the fd handler
+# can't touch $BUFFER/$POSTDISPLAY itself; only a real widget runs in editor context). Dispatching
+# by-name here lets _nh_on_response's tests drive that delegation end-to-end without a live ZLE.
+zle() {
+    [[ "$1" == -* ]] && return 0
+    (( $+functions[$1] )) && "$1"
+}
+bindkey() { : }
+export NIGHTHAWK_DEBOUNCE_MS=foo   # must be clamped to the 200 default, not left to throw later
+
+_nh_tmpcfg=$(mktemp -d)
+export XDG_CONFIG_HOME=$_nh_tmpcfg
+_nh_plugin="${0:A:h}/../nighthawk.zsh"
+if [[ ! -r "$_nh_plugin" ]]; then
+    print -u2 "async.test.zsh: cannot read $_nh_plugin"
+    rm -rf "$_nh_tmpcfg"
+    exit 2
+fi
+source "$_nh_plugin"
+rm -rf "$_nh_tmpcfg"
+
+# Structural check: the async seams must exist (guards against a rename or missing deps).
+if (( ! $+functions[_nh_handle_response] || ! $+functions[_nh_reply_is_fresh] || ! $+functions[_nh_has_ctrl_char] )); then
+    print -u2 "async.test.zsh: FAIL — async functions not defined after sourcing (renamed? deps missing?)"
+    exit 2
+fi
+
+# --- Assertion harness ---
+typeset -gi _nh_pass=0 _nh_fail=0
+check() {  # check <desc> <expected> <actual>
+    if [[ "$2" == "$3" ]]; then
+        (( _nh_pass++ ))
+    else
+        (( _nh_fail++ ))
+        print -r -- "FAIL: $1 — expected '$2' got '$3'"
+    fi
+}
+
+# Reset everything _nh_handle_response reads or writes, then point the snapshot at <buffer>/<cursor>.
+# BUFFER is set to match the snapshot because the render helpers index region_highlight off ${#BUFFER}.
+reset_state() {  # reset_state <buffer> <cursor>
+    _nh_suggestion=""
+    _nh_replace_start=""
+    _nh_replace_end=""
+    _nh_diff_ops=""
+    _nh_original_buffer=""
+    _nh_has_highlight=0
+    region_highlight=()
+    unset POSTDISPLAY
+    _nh_inflight_buffer="$1"
+    _nh_inflight_cursor="$2"
+    BUFFER="$1"
+    CURSOR="$2"
+}
+
+DEL=$'\x7f'   # 0x7f: a control char JSON permits raw, so it reaches _nh_has_ctrl_char through jq.
+
+# ---------------------------------------------------------------------------
+# 1. True prefix match -> suffix rendered as ghost (POSTDISPLAY), full text published.
+#    buffer "git ch" (6 bytes), replace [0,6), text "git checkout" -> ghost "eckout".
+# ---------------------------------------------------------------------------
+reset_state "git ch" 6
+_nh_handle_response '{"suggestions":[{"text":"git checkout","replace_start":0,"replace_end":6}]}'
+check "prefix: suggestion published" "git checkout" "$_nh_suggestion"
+check "prefix: ghost is the suffix"  "eckout"       "$POSTDISPLAY"
+
+# ---------------------------------------------------------------------------
+# 2. Replacement that changes the typed text -> hint (" -> text"), not an inline ghost.
+#    buffer "gti", replace [0,3), text "git status": longer than what's typed AND its first 3
+#    chars ("git") differ from the typed "gti", so it renders as a hint.
+# ---------------------------------------------------------------------------
+reset_state "gti" 3
+_nh_handle_response '{"suggestions":[{"text":"git status","replace_start":0,"replace_end":3}]}'
+check "replacement: suggestion published" "git status"               "$_nh_suggestion"
+check "replacement: rendered as hint"     " $_nh_hint_arrow git status" "$POSTDISPLAY"
+
+# ---------------------------------------------------------------------------
+# 3. Fuzzy match with diff_ops, default hint display mode -> hint POSTDISPLAY.
+# ---------------------------------------------------------------------------
+reset_state "gti" 3
+_nh_handle_response '{"suggestions":[{"text":"git status","replace_start":0,"replace_end":3,"diff_ops":[{"op":"keep","ch":"g"},{"op":"insert","ch":"i"}]}]}'
+check "fuzzy hint: suggestion published" "git status"               "$_nh_suggestion"
+check "fuzzy hint: hint rendered"        " $_nh_hint_arrow git status" "$POSTDISPLAY"
+
+# ---------------------------------------------------------------------------
+# 4. Control char in suggestion text -> fail closed, nothing published (RCE/escape guard).
+#    Raw 0x7f reaches $text through jq and must be rejected by _nh_has_ctrl_char before publish.
+# ---------------------------------------------------------------------------
+reset_state "ls" 2
+_nh_handle_response '{"suggestions":[{"text":"ls'"${DEL}"'x","replace_start":0,"replace_end":2}]}'
+check "ctrl in text: nothing published" "" "$_nh_suggestion"
+check "ctrl in text: no ghost"          "" "${POSTDISPLAY-}"
+
+# ---------------------------------------------------------------------------
+# 5. Clean text but a control char inside diff_ops -> still rejected (the per-op bytes reach BUFFER
+#    in diff mode, so a clean text with a tainted op must not slip the text-only check above).
+# ---------------------------------------------------------------------------
+reset_state "gti" 3
+_nh_handle_response '{"suggestions":[{"text":"git status","replace_start":0,"replace_end":3,"diff_ops":[{"op":"insert","ch":"'"${DEL}"'"}]}]}'
+check "ctrl in diff_ops: nothing published" "" "$_nh_suggestion"
+check "ctrl in diff_ops: no ghost"          "" "${POSTDISPLAY-}"
+
+# ---------------------------------------------------------------------------
+# 6. Out-of-range replace_end (past end of buffer) -> fail closed, never corrupt the buffer.
+# ---------------------------------------------------------------------------
+reset_state "ls" 2
+_nh_handle_response '{"suggestions":[{"text":"ls -la","replace_start":0,"replace_end":99}]}'
+check "oob range: nothing published" "" "$_nh_suggestion"
+check "oob range: no ghost"          "" "${POSTDISPLAY-}"
+
+# ---------------------------------------------------------------------------
+# 7. Empty suggestion list -> no-op.
+# ---------------------------------------------------------------------------
+reset_state "git" 3
+_nh_handle_response '{"suggestions":[]}'
+check "empty list: nothing published" "" "$_nh_suggestion"
+
+# ---------------------------------------------------------------------------
+# 8. _nh_has_ctrl_char primitive: the security gate itself, across the full rejected range.
+# ---------------------------------------------------------------------------
+ctrl_of() { _nh_has_ctrl_char "$1" && print detected || print clean }
+check "ctrl primitive: 0x01"       detected "$(ctrl_of $'\x01')"
+check "ctrl primitive: 0x1f"       detected "$(ctrl_of $'\x1f')"
+check "ctrl primitive: 0x7f (DEL)" detected "$(ctrl_of $'\x7f')"
+check "ctrl primitive: newline"    detected "$(ctrl_of $'a\nb')"
+check "ctrl primitive: clean text" clean    "$(ctrl_of 'git checkout --force')"
+
+# ---------------------------------------------------------------------------
+# 9. Staleness gate: _nh_reply_is_fresh is true iff the generation still matches dispatch. Buffer and
+#    cursor are deliberately NOT consulted — they're unreadable in the fd-handler context where this
+#    runs (see header note), and every buffer/cursor change already bumps the generation anyway.
+# ---------------------------------------------------------------------------
+fresh_of() {  # fresh_of <gen> <dispatch_gen> <buffer> <inflight_buffer> <cursor> <inflight_cursor>
+    _nh_gen=$1 _nh_dispatch_gen=$2 BUFFER="$3" _nh_inflight_buffer="$4" CURSOR=$5 _nh_inflight_cursor=$6
+    _nh_reply_is_fresh && print fresh || print stale
+}
+check "fresh: all match"          fresh "$(fresh_of 5 5 git git 3 3)"
+check "stale: generation moved"   stale "$(fresh_of 6 5 git git 3 3)"
+# Buffer/cursor differences do NOT mark stale on their own — only the generation gates freshness.
+check "fresh: buffer diff ignored" fresh "$(fresh_of 5 5 gitx git 4 3)"
+check "fresh: cursor diff ignored" fresh "$(fresh_of 5 5 git git 2 3)"
+
+# ---------------------------------------------------------------------------
+# 10. Load-time debounce validation: the non-numeric NIGHTHAWK_DEBOUNCE_MS=foo set before sourcing
+#     must have been clamped to the 200 default (otherwise / 1000.0 throws in the keystroke path).
+# ---------------------------------------------------------------------------
+check "debounce_ms clamped from non-numeric" 200 "$_nh_debounce_ms"
+
+# ---------------------------------------------------------------------------
+# 11. _nh_on_response drain loop — the seam the assertions above skip. Driven with REAL fds so it
+#     catches the two failure modes a plan-only review can't: a crash on every reply, and
+#     mid-stream truncation of a multi-chunk reply. (A regular file gives "data then EOF"
+#     deterministically; a <>-opened fifo gives "data, no EOF" to model a still-arriving reply.)
+# ---------------------------------------------------------------------------
+# 11a. A complete line delivered in one read -> drains, passes the freshness gate, renders the ghost
+#      and tears the fd down. (If `local status=$?` regressed, the handler would abort here and
+#      POSTDISPLAY would stay empty — this is the crash regression guard.)
+reset_state "git ch" 6
+_nh_gen=20 _nh_dispatch_gen=20
+_nh_resp_accum=""
+_nh_t=$(mktemp)
+print -r -- '{"suggestions":[{"text":"git checkout","replace_start":0,"replace_end":6}]}' > "$_nh_t"
+exec {_nh_fd}< "$_nh_t"; _nh_resp_fd=$_nh_fd
+_nh_on_response $_nh_fd ""
+check "on_response: full line renders ghost"     "eckout" "${POSTDISPLAY-}"
+check "on_response: fd torn down after finalize" 0        "$_nh_resp_fd"
+rm -f "$_nh_t"
+
+# 11b. Reply split across callbacks: a partial already sits in the accumulator and the fd carries
+#      the remainder -> the two must be joined (append, not overwrite) and parsed as one line.
+reset_state "git ch" 6
+_nh_gen=21 _nh_dispatch_gen=21
+_nh_resp_accum='{"suggestions":[{"text":"git che'
+_nh_t=$(mktemp)
+print -r -- 'ckout","replace_start":0,"replace_end":6}]}' > "$_nh_t"
+exec {_nh_fd}< "$_nh_t"; _nh_resp_fd=$_nh_fd
+_nh_on_response $_nh_fd ""
+check "on_response: accumulates across chunks" "eckout" "${POSTDISPLAY-}"
+rm -f "$_nh_t"
+
+# 11c. A partial with no newline and NO EOF (write end held open via <>) must NOT finalize — it
+#      stays registered for the next callback instead of truncating. Regression guard for the
+#      "while-loop masks the sysread status" bug: if would-block (4) were misread as done, this
+#      would tear the fd down and feed jq a truncated line.
+reset_state "ls" 2
+_nh_gen=22 _nh_dispatch_gen=22
+_nh_resp_accum=""
+_nh_fifo=$(mktemp -u); mkfifo "$_nh_fifo"
+exec {_nh_fd}<> "$_nh_fifo"          # read-write: readable, but never EOF while we hold it
+print -rn -- '{"suggestions":[{"text":"ls' >&$_nh_fd
+_nh_resp_fd=$_nh_fd
+_nh_on_response $_nh_fd ""
+check "on_response: partial w/o newline does not finalize" "" "${POSTDISPLAY-}"
+check "on_response: partial keeps fd registered" "$_nh_fd" "$_nh_resp_fd"
+exec {_nh_fd}<&-; rm -f "$_nh_fifo"
+
+# 11d. A complete line, but the generation moved on since dispatch (superseded by a later keystroke)
+#      -> drained and dropped by the freshness gate, nothing rendered.
+reset_state "git ch" 6
+_nh_gen=24 _nh_dispatch_gen=23       # dispatch one generation behind => stale
+_nh_resp_accum=""
+_nh_t=$(mktemp)
+print -r -- '{"suggestions":[{"text":"git checkout","replace_start":0,"replace_end":6}]}' > "$_nh_t"
+exec {_nh_fd}< "$_nh_t"; _nh_resp_fd=$_nh_fd
+_nh_on_response $_nh_fd ""
+check "on_response: stale generation renders nothing" "" "${POSTDISPLAY-}"
+rm -f "$_nh_t"
+
+# --- summary ---
+print -r -- "async.test.zsh: $_nh_pass passed, $_nh_fail failed"
+(( _nh_fail == 0 ))


### PR DESCRIPTION
## What

Converts the zsh plugin's IPC from **synchronous** (blocked the keystroke thread on every daemon round-trip) to **async** via `zle -F`, reaching parity with the PowerShell plugin's async model. Honors the CLAUDE.md rule: *"Never block the input loop in shell plugins."*

## Pipeline

```
keystroke -> _nh_schedule_query   snapshot $BUFFER/$CURSOR, arm a debounce timer
          -> _nh_debounce_fire    sleep-EOF timer fires
          -> _nh_dispatch         build JSON, spawn `socat` on a fresh fd
          -> _nh_on_response      non-blocking sysread drain (zsh/system), freshness gate
          -> _nh_apply_response   real widget: render in editor context
```

A **separate sleep-timer fd** holds the debounce, so a keystroke can cancel a pending query by closing the fd *before* `socat` ever spawns — coalescing keystrokes with zero daemon round-trips while typing.

## The `zle -F` gotcha (the crux)

A `zle -F` fd-handler runs **outside** the line-editor widget context: `$BUFFER`/`$CURSOR`/`$POSTDISPLAY` are unbound there (`$BUFFER` reads back empty) and a direct `zle -R` paints nothing. So the handler stashes the reply and bounces into a **real widget** via `zle _nh_apply_response`, which runs in editor context where those parameters are live and the display actually repaints.

Freshness is gated by a **generation counter only** — a buffer/cursor compare is meaningless in the handler context (empty values), and every keystroke bumps the generation anyway, so the counter is the complete signal.

## Tests

New `shells/tests/async.test.zsh` — 29 hermetic assertions: response parse/render, control-char guards, the `sysread` drain loop driven with real fds (regular file = data-then-EOF; `<>`-opened fifo = data-no-EOF), the generation freshness gate, and the fd-handler -> widget render delegation.

- async: **29/29 pass**
- offsets: **41/41 pass** (no regression)
- `zsh -n` clean

## Manual testing

Verified live in WSL zsh: prefix ghost text (`git ch` -> gray `eckout`), and the cloud-LLM tier (`jn` -> `journalctl …`, `source: cloud_model`) rendering async without blocking input — the exact ~500ms round-trip the old sync code would have stalled on per keystroke.