### PR TITLE
fix(zsh): remove only our own region_highlight entries via memo tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ sudo apt install socat jq    # Debian/Ubuntu
 brew install socat jq        # macOS
 ```
 
+**Syntax-highlighting coexistence.** On **zsh 5.9+** nighthawk tags its `region_highlight` entries with a `memo` field so it removes only its own ghost-text highlights — it coexists cleanly with `zsh-syntax-highlighting` and similar plugins regardless of load order. On zsh 5.8 and older (e.g. Ubuntu 22.04, Debian 11) `memo` isn't supported; nighthawk falls back to positional removal, which can briefly disturb a co-resident highlighter's coloring. Ghost text still works everywhere.
+
 **Optional AI tiers** are off by default (local-first, zero-config). Opt in at install time:
 
 ```sh

--- a/shells/nighthawk.zsh
+++ b/shells/nighthawk.zsh
@@ -140,8 +140,33 @@ typeset -g _nh_suggestion=""
 typeset -g _nh_replace_start=""
 typeset -g _nh_replace_end=""
 typeset -g _nh_last_buffer=""
+# Count of region_highlight entries we appended since the last clear. INVARIANT:
+# _nh_has_highlight == number of entries the active render path pushed onto
+# region_highlight (ghost/hint push 1; diff pushes one per colored char). The <=5.8
+# fallback in _nh_strip_highlights pops exactly this many from the tail, so the count
+# MUST equal entries-appended or that path mispops a co-resident plugin's entry. It's
+# also read as a boolean presence-flag by _nh_escape — keep it a count, not a bool.
 typeset -g _nh_has_highlight=0
 typeset -g _nh_diff_ops=""
+
+# region_highlight memo support (zsh 5.9+). The man page documents tagging entries with a
+# trailing `memo=token` field and removing them with `region_highlight=( ${arr:#*memo=token} )`,
+# which deletes OUR entries by identity regardless of array position — fixing the bug where a
+# co-resident highlighter (e.g. zsh-syntax-highlighting) that appended after us had its entries
+# stolen by positional tail-deletion (#10). zsh 5.8 and older neither support memo NOR parse the
+# style field correctly when one is present, so we gate on the version: tag + identity-filter on
+# 5.9+, fall back to the original positional pop (still buggy under co-resident plugins, but no
+# worse than before and the best old zsh allows) on <=5.8.
+autoload -Uz is-at-least
+typeset -g _nh_memo=0
+is-at-least 5.9 && _nh_memo=1
+# Single source of truth for the token: both the appended tag (render sites) and the strip glob
+# derive from it, so renaming can't desync the two and silently leave un-removable highlights.
+typeset -gr _nh_memo_token="nighthawk"
+# Suffix appended verbatim at every render site. Empty on <=5.8 → entries are byte-identical to
+# the pre-fix plugin. The leading space is load-bearing: it separates the memo from the style field.
+typeset -g _nh_memo_tag=""
+(( _nh_memo )) && _nh_memo_tag=" memo=$_nh_memo_token"
 typeset -g _nh_original_buffer=""
 typeset -g _nh_original_cursor=""
 typeset -g _nh_backoff_until=0
@@ -174,7 +199,7 @@ _nh_render_ghost() {
     local ghost="$1"
     if [[ -n "$ghost" ]]; then
         POSTDISPLAY="$ghost"
-        region_highlight+=("${#BUFFER} $((${#BUFFER} + ${#ghost})) fg=8")
+        region_highlight+=("${#BUFFER} $((${#BUFFER} + ${#ghost})) fg=8${_nh_memo_tag}")
         _nh_has_highlight=1
     fi
 }
@@ -207,11 +232,11 @@ _nh_render_diff() {
             k)  new_token+="$ch"; pos=$((pos + 1))
                 last_typed_pos=$pos ;;
             d)  new_token+="$ch"
-                diff_highlights+=("$pos $((pos + 1)) fg=red,bold")
+                diff_highlights+=("$pos $((pos + 1)) fg=red,bold${_nh_memo_tag}")
                 pos=$((pos + 1))
                 last_typed_pos=$pos ;;
             i)  new_token+="$ch"
-                diff_highlights+=("$pos $((pos + 1)) fg=8")
+                diff_highlights+=("$pos $((pos + 1)) fg=8${_nh_memo_tag}")
                 pos=$((pos + 1)) ;;
         esac
     done
@@ -243,7 +268,7 @@ _nh_render_hint() {
     local suggestion="$1"
     if [[ -n "$suggestion" ]]; then
         POSTDISPLAY=" $_nh_hint_arrow $suggestion"
-        region_highlight+=("${#BUFFER} $((${#BUFFER} + ${#POSTDISPLAY})) fg=8")
+        region_highlight+=("${#BUFFER} $((${#BUFFER} + ${#POSTDISPLAY})) fg=8${_nh_memo_tag}")
         _nh_has_highlight=1
     fi
 }
@@ -257,8 +282,7 @@ _nh_restore_before_edit() {
         CURSOR=${#BUFFER}  # end of original text
         _nh_original_buffer=""
         _nh_original_cursor=""
-        region_highlight=()
-        _nh_has_highlight=0
+        _nh_strip_highlights
         _nh_diff_ops=""
         _nh_suggestion=""
         _nh_replace_start=""
@@ -286,6 +310,29 @@ _nh_backward_kill_word() {
 }
 zle -N backward-kill-word _nh_backward_kill_word
 
+# Remove ONLY the region_highlight entries this plugin added, leaving any co-resident
+# highlighter's entries (e.g. zsh-syntax-highlighting) intact. Single chokepoint for every
+# "drop my ghost highlight" path so the removal strategy lives in one place (#10).
+#   5.9+ : identity-filter by memo — position-independent, the correct fix.
+#   <=5.8: pop the last _nh_has_highlight entries (no memo support). Positional, so it can still
+#          steal a co-resident plugin's tail entry — unavoidable without memo; see header note.
+# Does NOT touch POSTDISPLAY, the buffer, or suggestion state — callers own that teardown, which
+# differs per path (pre-redraw clear vs. accept vs. commit vs. pre-edit restore).
+_nh_strip_highlights() {
+    if (( _nh_memo )); then
+        # `:#pat` removes matching elements; (@) preserves element boundaries so an entry with
+        # spaces stays one element. The pattern has NO trailing wildcard: memo is the last field,
+        # so this is end-anchored and won't match a foreign `memo=nighthawk-companion`.
+        region_highlight=( "${(@)region_highlight:#*memo=$_nh_memo_token}" )
+    else
+        local i
+        for (( i = 0; i < _nh_has_highlight; i++ )); do
+            (( ${#region_highlight} )) && region_highlight[-1]=()
+        done
+    fi
+    _nh_has_highlight=0
+}
+
 _nh_clear_ghost() {
     # Cancel any pending debounce timer / in-flight request so a now-stale reply can't paint a
     # phantom ghost after the buffer moved on. This is the zsh analogue of nighthawk.ps1's
@@ -302,14 +349,8 @@ _nh_clear_ghost() {
     # backspace shows one char" glitch).
     unset POSTDISPLAY
 
-    # Remove the highlight entries we appended (zsh-native brace range — no subprocess).
-    if (( _nh_has_highlight )); then
-        local i
-        for i in {1..$_nh_has_highlight}; do
-            region_highlight[-1]=()
-        done
-        _nh_has_highlight=0
-    fi
+    # Remove only our highlight entries (memo-filter on 5.9+, positional pop on <=5.8).
+    _nh_strip_highlights
 
     # Restore original buffer if diff rendering modified it
     if [[ -n "$_nh_original_buffer" ]]; then
@@ -679,8 +720,7 @@ _nh_accept() {
 
         # Clear ghost/highlight state
         unset POSTDISPLAY
-        region_highlight=()
-        _nh_has_highlight=0
+        _nh_strip_highlights
         _nh_suggestion=""
         _nh_diff_ops=""
 
@@ -734,8 +774,9 @@ _nh_line_finish() {
     fi
 
     unset POSTDISPLAY
-    region_highlight=()
-    _nh_has_highlight=0
+    # Strip only our entries so a co-resident highlighter keeps coloring the committed line
+    # as it scrolls into scrollback (a full wipe would blank its final frame).
+    _nh_strip_highlights
     _nh_suggestion=""
     _nh_replace_start=""
     _nh_replace_end=""

--- a/shells/tests/highlight_memo_test.zsh
+++ b/shells/tests/highlight_memo_test.zsh
@@ -1,0 +1,132 @@
+#!/usr/bin/env zsh
+# Unit tests for _nh_strip_highlights in shells/nighthawk.zsh — the single chokepoint that
+# removes ONLY this plugin's region_highlight entries (issue #10). The old code popped the last
+# N entries positionally, which stole a co-resident highlighter's (e.g. zsh-syntax-highlighting)
+# entries whenever they were appended after ours. The fix tags our entries with `memo=nighthawk`
+# (zsh 5.9+) and removes by identity; on <=5.8 (no memo support) it falls back to the positional
+# pop. This test drives BOTH branches regardless of the host zsh version by forcing _nh_memo.
+#
+# Hermetic source mirrors offsets.test.zsh: stub the ZLE builtins so widget/keymap registration
+# is inert, isolate config to a temp dir.
+#
+# Run:  zsh shells/tests/highlight_memo_test.zsh
+emulate -L zsh
+
+# --- Hermetic source ---
+zle()     { : }
+bindkey() { : }
+
+_nh_tmpcfg=$(mktemp -d)
+export XDG_CONFIG_HOME=$_nh_tmpcfg
+_nh_plugin="${0:A:h}/../nighthawk.zsh"
+if [[ ! -r "$_nh_plugin" ]]; then
+    print -u2 "highlight_memo_test.zsh: cannot read $_nh_plugin"
+    rm -rf "$_nh_tmpcfg"
+    exit 2
+fi
+source "$_nh_plugin"
+rm -rf "$_nh_tmpcfg"
+
+# Structural check: the chokepoint and its state must exist (guards against a rename).
+if (( ! $+functions[_nh_strip_highlights] )); then
+    print -u2 "highlight_memo_test.zsh: FAIL — _nh_strip_highlights not defined (renamed? deps missing?)"
+    exit 2
+fi
+
+# --- Assertion harness ---
+typeset -gi _nh_pass=0 _nh_fail=0
+check() {  # check <desc> <expected> <actual>
+    if [[ "$2" == "$3" ]]; then
+        (( _nh_pass++ ))
+    else
+        (( _nh_fail++ ))
+        print -r -- "FAIL: $1 — expected '$2' got '$3'"
+    fi
+}
+# Join region_highlight with a '|' so order and content can be asserted as one string.
+joined() { local IFS='|'; print -r -- "${region_highlight[*]}" }
+
+# ====================================================================================
+# MEMO branch (zsh 5.9+): remove our entries by identity, regardless of array position.
+# Forced on so the branch is exercised even on a <=5.8 host. _nh_memo_token is set
+# unconditionally at source time, so the tag/glob are valid here on any version.
+# ====================================================================================
+_nh_memo=1
+_nh_memo_tag=" memo=$_nh_memo_token"
+
+# Adversarial layout: ours are NOT at the tail, and a foreign entry sits BETWEEN two of ours.
+# Includes the comma-style diff highlight and a foreign entry that ALSO uses memo=.
+region_highlight=(
+    "0 3 fg=green"                          # foreign, untagged (e.g. z-sy-h command)
+    "5 10 fg=8 memo=nighthawk"              # ours: ghost  (NOT at tail)
+    "4 8 fg=yellow memo=zsh-syntax-highlighting"  # foreign, memo-tagged by another plugin
+    "12 14 fg=red,bold memo=nighthawk"      # ours: diff delete (comma in style)
+    "15 16 fg=8 memo=nighthawk"             # ours: diff insert
+    "20 25 fg=cyan"                         # foreign, untagged (interleaved AFTER ours)
+    "30 40 fg=8 memo=nighthawk-companion"   # foreign look-alike — must NOT be stripped (anchor)
+)
+_nh_has_highlight=3
+_nh_strip_highlights
+check "memo: survivors + order preserved" \
+    "0 3 fg=green|4 8 fg=yellow memo=zsh-syntax-highlighting|20 25 fg=cyan|30 40 fg=8 memo=nighthawk-companion" \
+    "$(joined)"
+check "memo: no ours remain"        "" "${region_highlight[(r)* memo=nighthawk]}"
+check "memo: counter reset"          0 "$_nh_has_highlight"
+
+# Removing all of ours from an all-ours array yields a truly empty array (not [""]).
+region_highlight=( "1 2 fg=8 memo=nighthawk" "3 4 fg=8 memo=nighthawk" )
+_nh_has_highlight=2
+_nh_strip_highlights
+check "memo: all-ours -> empty array" 0 "${#region_highlight}"
+
+# No entries of ours present -> foreign array untouched.
+region_highlight=( "0 1 fg=green" "2 3 fg=red" )
+_nh_has_highlight=0
+_nh_strip_highlights
+check "memo: none-ours untouched"     "0 1 fg=green|2 3 fg=red" "$(joined)"
+
+# setopt-independence: :# is parameter expansion, not filename globbing, so glob options must
+# not change the result. Lock that claim explicitly rather than assuming it.
+setopt LOCAL_OPTIONS KSH_GLOB EXTENDED_GLOB NO_GLOB
+region_highlight=( "0 3 fg=green" "5 10 fg=8 memo=nighthawk" )
+_nh_has_highlight=1
+_nh_strip_highlights
+check "memo: setopt-independent"      "0 3 fg=green" "$(joined)"
+unsetopt KSH_GLOB EXTENDED_GLOB NO_GLOB
+
+# ====================================================================================
+# FALLBACK branch (zsh <=8.8, no memo): pop the last _nh_has_highlight entries.
+# Forced regardless of host. Positional by necessity, so our entries must be at the TAIL
+# (which is the real-world layout when no co-resident plugin appended after us).
+# ====================================================================================
+_nh_memo=0
+_nh_memo_tag=""
+
+# Single ghost entry at the tail.
+region_highlight=( "0 3 fg=green" "5 10 fg=8" )
+_nh_has_highlight=1
+_nh_strip_highlights
+check "fallback: pop 1 from tail"     "0 3 fg=green" "$(joined)"
+check "fallback: counter reset"        0 "$_nh_has_highlight"
+
+# Multi-entry diff: count must equal entries appended; all of ours popped.
+region_highlight=( "0 3 fg=green" "5 6 fg=red,bold" "6 7 fg=8" "7 8 fg=8" )
+_nh_has_highlight=3
+_nh_strip_highlights
+check "fallback: pop N(diff) from tail" "0 3 fg=green" "$(joined)"
+
+# Underflow guard: count larger than the array must not error or wrap.
+region_highlight=( "0 3 fg=green" )
+_nh_has_highlight=5
+_nh_strip_highlights
+check "fallback: underflow-safe"       0 "${#region_highlight}"
+
+# Empty array + zero count: no-op, no error.
+region_highlight=()
+_nh_has_highlight=0
+_nh_strip_highlights
+check "fallback: empty/zero no-op"     0 "${#region_highlight}"
+
+# --- summary ---
+print -r -- "highlight_memo_test.zsh: $_nh_pass passed, $_nh_fail failed"
+(( _nh_fail == 0 ))


### PR DESCRIPTION
## Summary

Fixes #10 — the zsh plugin removed its ghost-text highlights from the shared `region_highlight` array by **position** (`region_highlight[-1]=()` tail-deletion in `_nh_clear_ghost`, and wholesale `region_highlight=()` in `_nh_accept` / `_nh_line_finish` / `_nh_restore_before_edit`). When a co-resident highlighter such as `zsh-syntax-highlighting` appends its entries after ours, the tail-deletion steals theirs and the full wipe blanks them — causing flickering syntax colors and orphaned ghost highlights, depending on plugin load order.

## Fix

- Tag every entry nighthawk appends with a `memo=nighthawk` field (zsh 5.9+).
- New single chokepoint `_nh_strip_highlights` removes **by identity**: `region_highlight=( "${(@)region_highlight:#*memo=nighthawk}" )` — position-independent.
- All four clear paths route through the helper, so a co-resident plugin's highlights (including the final frame of a committed line) survive.
- **Version-gated** (`is-at-least 5.9`): tag + filter on 5.9+, original positional pop on ≤5.8 where `memo` is unsupported and would misparse the style field. No regression on old zsh — just unfixed where it can't be fixed. Ubuntu 22.04 / Debian 11 (zsh 5.8) keep working as before.
- The memo token is a single source of truth shared by the tag and the strip glob so they can't desync.

## Tests

Adds `shells/tests/highlight_memo_test.zsh` (11 assertions) exercising **both** code paths independent of the host zsh version (forces `_nh_memo`):
- adversarial ordering (our entries not at the tail, foreign entry interleaved between ours) — reproduces #10
- comma-style diff highlights (`fg=red,bold memo=nighthawk`)
- end-anchor guard (a foreign `memo=nighthawk-companion` must survive)
- setopt-independence (`KSH_GLOB`/`EXTENDED_GLOB`/`NO_GLOB`)
- fallback underflow safety

Full suite green: `highlight_memo` 11/11, `offsets` 41/41, `async` 29/29, `zsh -n` clean.

## Manual verification note

The synthetic suite validates the array-filter logic; it cannot exercise a live ZLE redraw against a real `zsh-syntax-highlighting` (needs an interactive terminal). Recommend a manual A/B (flip plugin load order) before relying on it in the wild.

Closes #10