### PR TITLE
feat: bash plugin with async inline autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Start typing a command — gray ghost text shows the completion. **Tab** (or **�
 
 > PowerShell: `nh setup powershell` instead, then restart your shell. (PowerShell has no `socat`/`jq` dependency.)
 
+> bash: `nh setup bash` instead, then `exec bash`. Requires `socat` + `jq` (like zsh). **Accept keys in bash are → (right arrow) and Ctrl-F — not Tab.** Tab stays bound to native completion by default, because bash's `bind -x` (unlike zsh's `zle expand-or-complete` or PowerShell's `TabCompleteNext`) cannot fall back to native completion once it's rebound. To make **Tab** accept the suggestion instead, set `tab_accept = true` under `[plugin]` in `~/.config/nighthawk/config.toml` (or `NIGHTHAWK_TAB_ACCEPT=1`) — but note this **disables native Tab-completion** in bash whenever no suggestion is showing. zsh and PowerShell are unaffected: they bind Tab to accept *and* keep native completion.
+
 ## Architecture
 
 Lightweight Rust daemon + thin shell plugins (~50 lines each). The daemon runs a tiered prediction cascade:
@@ -77,7 +79,7 @@ Lightweight Rust daemon + thin shell plugins (~50 lines each). The daemon runs a
 |-------|--------|
 | zsh | Supported |
 | PowerShell (5.1+, 7+) | Supported |
-| bash | Planned |
+| bash | Beta — accept on → / Ctrl-F (Tab opt-in, see Quickstart) |
 | fish | Planned |
 | nushell | Planned |
 

--- a/shells/nighthawk.bash
+++ b/shells/nighthawk.bash
@@ -1,31 +1,292 @@
 #!/usr/bin/env bash
-# nighthawk bash plugin
+# nighthawk bash plugin — inline ghost text autocomplete
+#
+# Install: add to ~/.bashrc:  source /path/to/nighthawk.bash
+# Requires: socat, jq
 #
 # Architecture:
-#   Uses bind -x to hook into readline. On each keystroke,
-#   reads $READLINE_LINE → sends JSON to daemon → renders ghost text.
+#   bash has no POSTDISPLAY (zsh) or PSReadLine prediction (PowerShell), so ghost
+#   text is drawn with raw ANSI escapes (PowerShell's model). bind -x hooks readline;
+#   READLINE_LINE/READLINE_POINT are the live buffer/cursor (POINT is a BYTE offset).
 #
-# Install:
-#   Add to ~/.bashrc: source /path/to/nighthawk.bash
-#
-# Contract:
-#   1. Connect to daemon socket
-#   2. On keystroke: send CompletionRequest JSON
-#   3. Read CompletionResponse JSON
-#   4. Render ghost text via ANSI escapes after cursor
-#   5. Tab: accept suggestion into READLINE_LINE
+# This file is the SESSION-1 layer: the pure, side-effect-free helpers (config,
+# logging, control-char guard, UTF-8 offset conversion, JSON request build, response
+# parse, prefix-vs-hint decision) plus a thin pipeline that composes them. It loads
+# but is otherwise INERT — no key bindings, no rendering. Session 2 adds rendering +
+# bindings; Session 3 adds the async IPC core. The helpers are factored exactly so the
+# later sessions compose them without re-deriving any of this logic — mirroring how the
+# PowerShell plugin factored its $_nh_worker body.
 
 NIGHTHAWK_SOCKET="${NIGHTHAWK_SOCKET:-/tmp/nighthawk-$(id -u).sock}"
 
-# TODO: Implement using bind -x and READLINE_LINE/READLINE_POINT
-# bind -x '"\C-_": _nh_suggest'
+# --- Configuration ---
+# Defaults mirror the PowerShell plugin's keys. The arrow differs by design: bash/PS use
+# ASCII "->", zsh keeps the Unicode "→". Config dir matches the daemon's resolution
+# (dirs::config_dir() == ${XDG_CONFIG_HOME:-$HOME/.config}/nighthawk on Linux/WSL).
+_nh_hint_arrow="->"
+_nh_debounce_ms=200
+_nh_debug=0
+_nh_log_path="${XDG_CONFIG_HOME:-$HOME/.config}/nighthawk/plugin.log"
 
-_nh_suggest() {
-    # Placeholder — will query daemon over socket
-    :
+# Minimal hand-rolled TOML reader: walks lines, tracks the current [section], and pulls
+# the three keys we care about from [plugin]. No real parser, to stay dep-free.
+#
+# Two bash-specific load-bearing details vs. the zsh sibling:
+#   - The ERE patterns are stored in vars and used UNQUOTED on the right of `=~`. A
+#     quoted regex literal in bash is matched LITERALLY, which would silently make every
+#     line fail to match and config parsing a no-op (defaults always win). Single-quoting
+#     the assignment keeps the metacharacters intact without premature expansion.
+#   - The loop reads via `done < "$file"` REDIRECTION, never a pipe: a piped `while`
+#     runs in a subshell and the _nh_* assignments would be lost on exit.
+# `BASH_REMATCH` is clobbered by the next `=~`, so each capture is consumed immediately.
+_nh_load_config() {
+    local config_file="${XDG_CONFIG_HOME:-$HOME/.config}/nighthawk/config.toml"
+    [[ -f "$config_file" ]] || return 0
+    local re_section='^[[:space:]]*\[([^]]+)\][[:space:]]*$'
+    local re_arrow='^[[:space:]]*hint_arrow[[:space:]]*=[[:space:]]*"([^"]*)"'
+    local re_debounce='^[[:space:]]*debounce_ms[[:space:]]*=[[:space:]]*([0-9]+)'
+    local re_debug='^[[:space:]]*debug[[:space:]]*=[[:space:]]*(true|false)'
+    local line in_plugin=0
+    # `|| [[ -n "$line" ]]` processes a final line with no trailing newline, which `read`
+    # would otherwise drop. A trailing CRLF \r from a Windows-edited file is harmless: the
+    # value regexes capture before it, and \r is in [[:space:]] so the section anchor still
+    # matches "[plugin]\r".
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        if [[ "$line" =~ $re_section ]]; then
+            [[ "${BASH_REMATCH[1]}" == plugin ]] && in_plugin=1 || in_plugin=0
+            continue
+        fi
+        (( in_plugin )) || continue
+        if [[ "$line" =~ $re_arrow ]]; then
+            _nh_hint_arrow="${BASH_REMATCH[1]}"
+        elif [[ "$line" =~ $re_debounce ]]; then
+            _nh_debounce_ms="${BASH_REMATCH[1]}"
+        elif [[ "$line" =~ $re_debug ]]; then
+            [[ "${BASH_REMATCH[1]}" == true ]] && _nh_debug=1 || _nh_debug=0
+        fi
+    done < "$config_file"
+}
+_nh_load_config
+
+# Env vars win over config.toml (precedence env > file > default).
+[[ -n "$NIGHTHAWK_HINT_ARROW" ]] && _nh_hint_arrow="$NIGHTHAWK_HINT_ARROW"
+[[ -n "$NIGHTHAWK_DEBOUNCE_MS" ]] && _nh_debounce_ms="$NIGHTHAWK_DEBOUNCE_MS"
+if [[ -n "$NIGHTHAWK_DEBUG" ]]; then
+    [[ "$NIGHTHAWK_DEBUG" == "1" ]] && _nh_debug=1 || _nh_debug=0
+fi
+
+# Validate debounce_ms before it ever reaches arithmetic. The config regex only accepts
+# digits, but the env override is unguarded — a stray NIGHTHAWK_DEBOUNCE_MS=foo would
+# otherwise throw from inside the keystroke path. Reset to default on non-digit input,
+# then normalize with the base-10 prefix so a leading-zero value (e.g. "0200") is NOT
+# parsed as octal by $(( )).
+[[ "$_nh_debounce_ms" =~ ^[0-9]+$ ]] || _nh_debounce_ms=200
+_nh_debounce_ms=$(( 10#$_nh_debounce_ms ))
+
+# --- Diagnostic logging ---
+# No-op unless debug is on. Millisecond timestamps via GNU date's %N (Linux/WSL); on a
+# non-GNU date the literal "%3N" appears in the log — harmless, and never aborts.
+_nh_log() {
+    (( _nh_debug )) || return 0
+    printf '%s %s\n' "$(date '+%H:%M:%S.%3N' 2>/dev/null)" "$1" >> "$_nh_log_path" 2>/dev/null
 }
 
-_nh_accept() {
-    # Placeholder — will insert suggestion into READLINE_LINE
-    :
+# --- Control-char guard ---
+# True if $1 contains a C0 control char (0x01-0x1f) or DEL (0x7f). Single source of truth
+# for the fail-closed rejection of daemon suggestions before they reach the buffer: an
+# embedded newline auto-submits on accept (single-keystroke RCE if a model emits
+# `rm -rf $HOME\n`); an embedded ESC hijacks the terminal during render. Shell commands
+# never legitimately contain control chars, so reject (never strip — stripping merges
+# tokens around the dropped byte). `local LC_ALL=C` forces byte semantics so the bracket
+# RANGE uses C collation (a UTF-8 locale would make the range match unpredictably and
+# could let a control char slip or falsely reject a multibyte char). 0x00 is unreachable —
+# a literal NUL can't survive command substitution — so the floor is 0x01.
+_nh_has_ctrl_char() {
+    local LC_ALL=C
+    [[ $1 == *[$'\x01'-$'\x1f']* || $1 == *$'\x7f'* ]]
 }
+
+# --- UTF-8 byte offset <-> char index conversion ---
+# The daemon speaks UTF-8 BYTE offsets (replace_start/replace_end and the request cursor);
+# bash buffer subscripts and READLINE_POINT math need CHAR indices under a UTF-8 locale.
+# These bridge the two. The mechanic, validated empirically: a char-domain slice taken in
+# the ambient UTF-8 locale, then re-measured under `local LC_ALL=C`, yields that slice's
+# byte length. The locale flip is per-function and never leaks. Both fail CLOSED (-1 / a
+# clamp) so a malformed offset can never corrupt the buffer.
+#
+# CRITICAL ordering: the char-slice expansion (${s:0:n} / ${s:c-1:1}) MUST happen while the
+# UTF-8 CTYPE is still active; only the ${#...} measurement runs under LC_ALL=C. Putting
+# LC_ALL=C on the same `local` line as a slice would slice by byte and be silently wrong.
+
+# Byte offset -> char index (count of leading chars). Fail-closed -1 for a negative offset,
+# one past the end, or one landing inside a multibyte sequence (detected by overshoot).
+_nh_byte_to_char() {
+    local s=$1 boff=$2
+    (( boff < 0 )) && { printf '%s' -1; return; }
+    (( boff == 0 )) && { printf '%s' 0; return; }
+    local n=${#s} c                       # n = char count (UTF-8)
+    local -a chars=()
+    for (( c = 1; c <= n; c++ )); do chars[c]=${s:c-1:1}; done   # per-char slices (UTF-8)
+    local LC_ALL=C                        # measure byte widths under C, single context
+    local acc=0
+    for (( c = 1; c <= n; c++ )); do
+        (( acc += ${#chars[c]} ))
+        (( acc == boff )) && { printf '%s' "$c"; return; }   # exact code-point boundary
+        (( acc > boff )) && { printf '%s' -1; return; }      # offset split a multibyte char
+    done
+    printf '%s' -1                        # offset past the last byte
+}
+
+# Char index -> byte offset. One slice + measure (no walk needed). Clamps an over-long
+# index to the char length; returns 0 for <= 0.
+_nh_char_to_byte() {
+    local s=$1 cidx=$2
+    (( cidx <= 0 )) && { printf '%s' 0; return; }
+    local n=${#s}                         # char count (UTF-8)
+    (( cidx > n )) && cidx=$n
+    local slice=${s:0:cidx}               # char-domain slice, taken in UTF-8
+    local LC_ALL=C                        # now measure its bytes
+    printf '%s' "${#slice}"
+}
+
+# --- JSON string escaping ---
+# SINGLE source of request-side escaping; _nh_build_request delegates here. This is the
+# OUTBOUND direction (serializing the user's own buffer / cwd) and is independent of the
+# inbound _nh_has_ctrl_char rejection: a literal tab or newline pasted into the buffer is
+# illegal raw inside a JSON string (RFC 8259), so the daemon would reject the whole
+# request — hence the full control-char set, matching the PowerShell escaper. Chars >=0x20
+# (including all multibyte UTF-8) pass through RAW so the daemon's byte offsets over the
+# input agree with ours.
+_nh_json_escape() {
+    local s=$1
+    s=${s//\\/\\\\}        # backslash first
+    s=${s//\"/\\\"}        # then quote
+    s=${s//$'\b'/\\b}
+    s=${s//$'\f'/\\f}
+    s=${s//$'\n'/\\n}
+    s=${s//$'\r'/\\r}
+    s=${s//$'\t'/\\t}
+    # Remaining C0 control chars (0x01-0x1f minus the named ones above) -> \u00XX. The
+    # quoted "$ctrl" makes each a LITERAL single-byte substring match (no locale-sensitive
+    # range), so no LC_ALL needed. Rare in shell input; 26 cheap checks on a short string.
+    local code octal ctrl hex
+    for code in 1 2 3 4 5 6 7 11 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31; do
+        printf -v octal '%03o' "$code"
+        printf -v ctrl "\\$octal"
+        [[ "$s" == *"$ctrl"* ]] || continue
+        printf -v hex '\\u%04x' "$code"
+        s=${s//"$ctrl"/$hex}
+    done
+    printf '%s' "$s"
+}
+
+# --- Request build ---
+# Pure string -> string. Takes the cursor ALREADY converted to a byte offset (the
+# char->byte conversion belongs at snapshot time in the S3 dispatch, not here). Emits
+# "shell":"bash" so the daemon routes to bash history / detection.
+_nh_build_request() {
+    local input=$1 cursor_bytes=$2 cwd=$3
+    printf '{"input":"%s","cursor":%s,"cwd":"%s","shell":"bash"}' \
+        "$(_nh_json_escape "$input")" "$cursor_bytes" "$(_nh_json_escape "$cwd")"
+}
+
+# --- Response parse ---
+# Emits eval-able assignments for the first suggestion: text / replace_start / replace_end
+# (jq @sh-quoted) and a bare diff_ops_present 0|1 flag. The caller MUST declare these as
+# locals (defaulted) BEFORE `eval "$(_nh_parse_response ...)"` so a jq failure (malformed
+# JSON, swallowed by 2>/dev/null) leaves them empty rather than stale from a prior call.
+# Only suggestions[0] is used, matching the zsh/PowerShell plugins.
+_nh_parse_response() {
+    printf '%s' "$1" | jq -r '
+        if (.suggestions | length) > 0 then
+            "text=" + (.suggestions[0].text | @sh)
+            + " replace_start=" + ((.suggestions[0].replace_start | tostring) | @sh)
+            + " replace_end=" + ((.suggestions[0].replace_end | tostring) | @sh)
+            + " diff_ops_present=" + (if (.suggestions[0].diff_ops // null) then "1" else "0" end)
+        else
+            "text=" + ("" | @sh) + " replace_start=" + ("" | @sh)
+            + " replace_end=" + ("" | @sh) + " diff_ops_present=0"
+        end
+    ' 2>/dev/null
+}
+
+# --- Prefix-vs-hint decision ---
+# Pure. Echoes a tagged, display-ready payload for the S2 renderer to dispatch on:
+#   ghost<TAB><suffix>   true prefix match — render <suffix> as ghost after the cursor
+#   hint<TAB> -> <text>  replacement / fuzzy — render as a hint
+#   (empty)              nothing to show
+# bash follows the PowerShell hint-only model: a fuzzy match (diff_ops present) always
+# renders as a hint; there is no inline-diff renderer. <rstart_chars> is the CHAR-domain
+# replace_start (already byte->char converted). Self-guards rstart so a -1 from a failed
+# conversion can never reach the ${buffer:rstart:...} subscript across the S2/S3 seam.
+# <snapshot_buffer> MUST be the same buffer snapshot whose bytes fed _nh_build_request and
+# the offset conversion — never live READLINE_LINE. Typed length is derived from the buffer
+# length because the suggest path only ever fires with the cursor at end-of-line.
+_nh_decide_render() {
+    local buffer=$1 text=$2 rstart=$3 diff_present=$4
+    [[ -n "$text" ]] || return 0
+    [[ "$rstart" =~ ^[0-9]+$ ]] || return 0
+    local blen=${#buffer}
+    (( rstart > blen )) && return 0
+    if (( diff_present )); then
+        printf 'hint\t %s %s' "$_nh_hint_arrow" "$text"
+        return 0
+    fi
+    local typed_len=$(( blen - rstart ))
+    (( typed_len >= 0 && typed_len < ${#text} )) || return 0
+    local typed_part=${buffer:rstart:typed_len}
+    if [[ "${text:0:typed_len}" == "$typed_part" ]]; then
+        printf 'ghost\t%s' "${text:typed_len}"      # true prefix: suffix as ghost
+    else
+        printf 'hint\t %s %s' "$_nh_hint_arrow" "$text"   # replacement: hint
+    fi
+}
+
+# --- Response pipeline (pure) ---
+# Composes parse -> control-char reject -> byte->char convert -> range-validate -> decide
+# against a buffer SNAPSHOT and a raw daemon reply, echoing the _nh_decide_render result.
+# Kept as one tested seam (the bash counterpart of the zsh _nh_handle_response body) so the
+# S3 async path can drive it with a canned reply; S2 only adds the actual render of the tag.
+_nh_compute_suggestion() {
+    local buffer=$1 response=$2
+    local text='' replace_start='' replace_end='' diff_ops_present=0
+    eval "$(_nh_parse_response "$response")"
+    [[ -n "$text" ]] || return 0
+    # Fail-closed: drop any suggestion carrying a control char before it can be rendered
+    # or accepted.
+    if _nh_has_ctrl_char "$text"; then
+        _nh_log "rejected: control char in suggestion"
+        return 0
+    fi
+    # Reject a non-integer range (e.g. "null" from a malformed reply) before arithmetic.
+    [[ "$replace_start" =~ ^[0-9]+$ && "$replace_end" =~ ^[0-9]+$ ]] || return 0
+    # Protocol byte offsets -> char indices against the snapshot buffer. Fail closed if
+    # either is out of range or splits a multibyte char.
+    local rstart rend
+    rstart=$(_nh_byte_to_char "$buffer" "$replace_start")
+    rend=$(_nh_byte_to_char "$buffer" "$replace_end")
+    if (( rstart < 0 || rend < 0 || rend < rstart )); then
+        _nh_log "rejected: replace range not on a code-point boundary"
+        return 0
+    fi
+    _nh_decide_render "$buffer" "$text" "$rstart" "$diff_ops_present"
+}
+
+# --- Dependency check ---
+# After the pure helpers (mirrors nighthawk.zsh ordering) so the unit harness can source
+# this file and exercise the helpers structurally even on a machine without the deps — and
+# so a "helper not defined" test failure means "renamed", not "deps missing".
+if ! command -v socat >/dev/null 2>&1; then
+    echo "nighthawk: socat not found, install with: apt install socat" >&2
+    return 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    echo "nighthawk: jq not found, install with: apt install jq" >&2
+    return 1
+fi
+
+# --- Inert placeholders ---
+# Session 2 wires rendering + readline key bindings (bind -x); Session 3 wires async IPC.
+# Defined as no-ops so the plugin loads cleanly without yet touching terminal state.
+_nh_suggest() { :; }
+_nh_accept()  { :; }

--- a/shells/nighthawk.bash
+++ b/shells/nighthawk.bash
@@ -26,6 +26,11 @@ NIGHTHAWK_SOCKET="${NIGHTHAWK_SOCKET:-/tmp/nighthawk-$(id -u).sock}"
 _nh_hint_arrow="->"
 _nh_debounce_ms=200
 _nh_debug=0
+# bash-ONLY opt-in: bind Tab to accept the suggestion. Default OFF because, unlike zsh/PowerShell
+# (whose editors can fall back to native completion via `zle expand-or-complete` / `TabCompleteNext`),
+# bash's `bind -x` CANNOT invoke readline completion — so binding Tab here means giving up native
+# Tab-completion when no suggestion is showing. Right arrow + Ctrl-F are always accept keys regardless.
+_nh_tab_accept=0
 _nh_log_path="${XDG_CONFIG_HOME:-$HOME/.config}/nighthawk/plugin.log"
 
 # Minimal hand-rolled TOML reader: walks lines, tracks the current [section], and pulls
@@ -46,6 +51,7 @@ _nh_load_config() {
     local re_arrow='^[[:space:]]*hint_arrow[[:space:]]*=[[:space:]]*"([^"]*)"'
     local re_debounce='^[[:space:]]*debounce_ms[[:space:]]*=[[:space:]]*([0-9]+)'
     local re_debug='^[[:space:]]*debug[[:space:]]*=[[:space:]]*(true|false)'
+    local re_tab='^[[:space:]]*tab_accept[[:space:]]*=[[:space:]]*(true|false)'
     local line in_plugin=0
     # `|| [[ -n "$line" ]]` processes a final line with no trailing newline, which `read`
     # would otherwise drop. A trailing CRLF \r from a Windows-edited file is harmless: the
@@ -63,6 +69,8 @@ _nh_load_config() {
             _nh_debounce_ms="${BASH_REMATCH[1]}"
         elif [[ "$line" =~ $re_debug ]]; then
             [[ "${BASH_REMATCH[1]}" == true ]] && _nh_debug=1 || _nh_debug=0
+        elif [[ "$line" =~ $re_tab ]]; then
+            [[ "${BASH_REMATCH[1]}" == true ]] && _nh_tab_accept=1 || _nh_tab_accept=0
         fi
     done < "$config_file"
 }
@@ -74,6 +82,9 @@ _nh_load_config
 if [[ -n "$NIGHTHAWK_DEBUG" ]]; then
     [[ "$NIGHTHAWK_DEBUG" == "1" ]] && _nh_debug=1 || _nh_debug=0
 fi
+if [[ -n "$NIGHTHAWK_TAB_ACCEPT" ]]; then
+    [[ "$NIGHTHAWK_TAB_ACCEPT" == "1" ]] && _nh_tab_accept=1 || _nh_tab_accept=0
+fi
 
 # Validate debounce_ms before it ever reaches arithmetic. The config regex only accepts
 # digits, but the env override is unguarded — a stray NIGHTHAWK_DEBOUNCE_MS=foo would
@@ -82,6 +93,44 @@ fi
 # parsed as octal by $(( )).
 [[ "$_nh_debounce_ms" =~ ^[0-9]+$ ]] || _nh_debounce_ms=200
 _nh_debounce_ms=$(( 10#$_nh_debounce_ms ))
+
+# Integer-ms -> fractional-seconds for the worker's debounce `sleep` (Session 3). Bash has no
+# float math, so this is pure STRING SPLICING: floor to a 10ms minimum (ms=0 would mean
+# `sleep 0` = NO debounce = a socat-fork-per-keystroke storm), zero-pad to >=4 digits, then
+# splice a "." three places from the right. The zero-pad is load-bearing: 50 -> "0050" -> "0.050"
+# (NOT "0.50", the silent 10x bug). The SPACE in ${p: -3} is also load-bearing — ${p:-3} (no
+# space) is the default-value operator and would yield "0050.0050". Input is already 10#-normalized
+# above, so printf only ever sees a clean decimal (no octal/sign surprise); %04d guarantees >=4
+# chars so the integer part (strip 3) is never empty. Kept a pure function so the harness can
+# assert the rows (200->0.200, 50->0.050, 1500->1.500, 10000->10.000, 10->0.010, 0->0.010).
+_nh_ms_to_sec() {
+    local ms=$1 p
+    (( ms < 10 )) && ms=10
+    printf -v p '%04d' "$ms"
+    printf '%s' "${p%???}.${p: -3}"
+}
+_nh_debounce_sec=$(_nh_ms_to_sec "$_nh_debounce_ms")
+
+# --- Live-state (Session 3: async direct-paint) ---
+# bash has no POSTDISPLAY (zsh) or `zle -F` fd-callback, so async rendering is done by a
+# background WORKER that paints the ghost straight to /dev/tty and round-trips the accept
+# payload through a `stash` FILE. These globals hold the cross-process coordination state.
+#   _nh_esc            ESC byte for the ANSI ghost sequences.
+#   _nh_gen            monotonic generation counter (in-process authority). Bumped on every
+#                      bound keystroke; mirrored to "$_nh_run_dir/gen" at dispatch so a worker
+#                      can detect it was superseded. The SOLE staleness token.
+#   _nh_run_dir        per-load nonce'd dir holding `gen` + `stash` (set by _nh_state_init in the
+#                      interactive guard; empty when sourced non-interactively => helpers no-op).
+#   _nh_backoff_until  epoch-seconds gate; a missing socket arms a 5s backoff so dispatch can't
+#                      hammer a dead daemon. (A present-but-hung daemon just costs one off-thread
+#                      worker that eats socat -t3 — never a freeze, so no cross-process marker.)
+# RETIRED vs S2: _nh_ghost_len (presence is now stash-file existence; clear is unconditional),
+# _nh_sug_text/_nh_sug_bstart/_nh_sug_bend (the accept payload is cross-process now — it lives in
+# the `stash` file), and _nh_render_ghost (folded into the worker's single _nh_tty_write sink).
+_nh_esc=$'\033'
+_nh_gen=0
+_nh_run_dir=""
+_nh_backoff_until=0
 
 # --- Diagnostic logging ---
 # No-op unless debug is on. Millisecond timestamps via GNU date's %N (Linux/WSL); on a
@@ -148,6 +197,13 @@ _nh_char_to_byte() {
     local LC_ALL=C                        # now measure its bytes
     printf '%s' "${#slice}"
 }
+
+# Byte length of a whole string == the byte offset of its EOL. This is the load-bearing
+# "is the cursor (READLINE_POINT, a byte offset) at end-of-line?" quantity — factored out so
+# _nh_dispatch/_nh_worker and _nh_forward_or_accept/_nh_accept compute it identically and can't
+# drift. NOT ${#1}, which is a CHAR count under a UTF-8 locale and wrong for the byte-offset
+# comparison.
+_nh_eol_bytes() { _nh_char_to_byte "$1" "${#1}"; }
 
 # --- JSON string escaping ---
 # SINGLE source of request-side escaping; _nh_build_request delegates here. This is the
@@ -223,6 +279,9 @@ _nh_parse_response() {
 #   ghost<TAB><suffix>     true prefix match — render <suffix> as ghost after the cursor
 #   hint<TAB> -> <text>    replacement / fuzzy — render as a hint
 #   (empty)                nothing to show
+# This 2-field `<tag>\t<payload>` shape is _nh_decide_render's OWN contract. _nh_compute_suggestion
+# wraps it with three more fields (byte range + replacement text) for the accept path — see there;
+# the FIRST-TAB split below still recovers tag/payload from either shape.
 # S2 PARSE CONTRACT: split on the FIRST TAB (e.g. `IFS=$'\t' read -r tag payload`). The
 # hint payload's LEADING SPACE is load-bearing — it is part of the rendered prefix
 # (" -> <text>"), matching the leading space the zsh/PS renderers prepend; S2 MUST emit
@@ -262,9 +321,14 @@ _nh_decide_render() {
 
 # --- Response pipeline (pure) ---
 # Composes parse -> control-char reject -> byte->char convert -> range-validate -> decide
-# against a buffer SNAPSHOT and a raw daemon reply, echoing the _nh_decide_render result.
-# Kept as one tested seam (the bash counterpart of the zsh _nh_handle_response body) so the
-# S3 async path can drive it with a canned reply; S2 only adds the actual render of the tag.
+# against a buffer SNAPSHOT and a raw daemon reply. Output is the 5-field record
+#   <kind>\t<display>\t<bstart>\t<bend>\t<text>
+# (empty when there is nothing to show): the 2-field display tag from _nh_decide_render plus
+# the daemon's BYTE range and full replacement text for the accept path. _nh_worker splits it
+# (IFS=$'\t'), paints <display>, and writes gen0/bstart/bend/text to the `stash` FILE that
+# _nh_accept reads — the stash file is the durable cross-process interface, so the async worker
+# can drive this with a real reply and stash identically without re-splitting anything downstream.
+# Kept as one tested seam (the bash counterpart of the zsh _nh_handle_response body).
 _nh_compute_suggestion() {
     local buffer=$1 response=$2
     # _nh_parse_response is self-defaulting (resets all four even on a jq failure), so these
@@ -296,7 +360,20 @@ _nh_compute_suggestion() {
         _nh_log "rejected: replace range not on a code-point boundary"
         return 0
     fi
-    _nh_decide_render "$buffer" "$text" "$rstart" "$diff_ops_present"
+    local tag
+    tag=$(_nh_decide_render "$buffer" "$text" "$rstart" "$diff_ops_present")
+    [[ -n "$tag" ]] || return 0
+    # Append the ACCEPT payload as three more TAB fields, making the full record:
+    #   <kind>\t<display>\t<bstart>\t<bend>\t<text>
+    # bstart/bend are the daemon's own BYTE offsets (already base-10 normalized above), NOT
+    # the char offsets fed to _nh_decide_render — accept splices in the byte domain, so it
+    # wants bytes. The byte->char conversion above stays purely as the fail-closed
+    # code-point-boundary guard (a mid-char offset is rejected before we ever get here).
+    # _nh_decide_render's own 2-field display contract is unchanged; only THIS function emits
+    # the 5-field record, and _nh_worker splits it. Safe to TAB-join: _nh_has_ctrl_char
+    # already rejected any suggestion containing a literal TAB (0x09), so neither <display>
+    # nor <text> can carry one.
+    printf '%s\t%s\t%s\t%s' "$tag" "$replace_start" "$replace_end" "$text"
 }
 
 # --- Dependency check ---
@@ -312,8 +389,395 @@ if ! command -v jq >/dev/null 2>&1; then
     return 1
 fi
 
-# --- Inert placeholders ---
-# Session 2 wires rendering + readline key bindings (bind -x); Session 3 wires async IPC.
-# Defined as no-ops so the plugin loads cleanly without yet touching terminal state.
-_nh_suggest() { :; }
-_nh_accept()  { :; }
+# ======================================================================================
+# SESSION 3: async direct-paint IPC + accept-splice + key bindings (the live layer).
+#
+# bash has no `zle -F` fd-callback and no way to programmatically re-enter the line editor, so
+# async rendering can't be driven from the foreground. Empirically (see the dev wake-spike), a
+# background WORKER that writes the ghost straight to /dev/tty SURVIVES while idle, because nothing
+# triggers a readline redisplay to erase it; a signal+trap paint, by contrast, gets wiped by
+# readline's post-trap redisplay. So: the foreground keystroke fire-and-forgets a worker; the
+# worker sleeps the debounce, queries the daemon, and (if not superseded) PAINTS the ghost then
+# writes the accept payload to a `stash` FILE. A monotonic generation counter (`gen` file) is the
+# cross-process staleness token; accept reads + revalidates the stash against the live buffer.
+#
+# KNOWN LIMITATIONS (documented, not bugs):
+#  - Unbound editing keys not in our set (history Up/Down, Ctrl-R, Ctrl-K/U/W, …) don't bump the
+#    generation, so an in-flight worker can paint once mid-line; the next bound key clears it.
+#    Common cursor MOVES (Left/Home/End) ARE bound to clear+invalidate. Ctrl-K/U/W are left native
+#    on purpose — reimplementing them in bash would break the kill-ring (Ctrl-Y yank).
+#  - A stale ghost can linger one keystroke under fast typing (worker preempted between its final
+#    generation check and the tty write). Bounded + self-healing; accept revalidates against the
+#    LIVE buffer so a stale ghost can never be ACCEPTED. If interleave corruption is ever visible,
+#    flip on the flock in _nh_tty_write (one place — see there).
+#  - Bracketed paste bypasses per-char bindings (no ghost during paste — fine).
+#  - Bindings install in the emacs keymap; vi-mode keymaps are untouched.
+#  - Escape-to-dismiss binds bare \e (see the bindings note); a LONE Esc waits keyseq-timeout.
+# ======================================================================================
+
+# --- Per-session state dir + cross-process generation ---
+# The run dir holds `gen` (generation) and `stash` (accept payload). The per-load $RANDOM NONCE
+# makes re-source teardown real: a new load picks a fresh path, so any in-flight worker from a
+# prior load reads `cat gen` -> ENOENT and exits. Created INSIDE the interactive guard; an unset
+# _nh_run_dir (non-interactive source, e.g. the unit harness) makes every helper below a no-op.
+_nh_state_init() {
+    local base="${TMPDIR:-/tmp}" d pid
+    # Reap THIS shell's prior-load dirs (re-source: same PID, the new dir isn't created yet).
+    for d in "$base"/nighthawk-plugin-"$$"-*; do
+        [[ -d "$d" && "$d" == */nighthawk-plugin-* ]] && rm -rf -- "$d"
+    done
+    # Opportunistic GC of crashed/HUP'd OTHER sessions whose PID is no longer alive.
+    for d in "$base"/nighthawk-plugin-*; do
+        [[ -d "$d" ]] || continue
+        pid=${d##*/nighthawk-plugin-}; pid=${pid%%-*}
+        [[ "$pid" =~ ^[0-9]+$ ]] || continue
+        kill -0 "$pid" 2>/dev/null && continue
+        [[ "$d" == */nighthawk-plugin-* ]] && rm -rf -- "$d"
+    done
+    # mktemp -d atomically creates a 0700 dir with an unpredictable suffix and FAILS on collision.
+    # This closes the predictable-name window: `mkdir -p $$-$RANDOM` would ACCEPT a dir another
+    # local user pre-created on a world-writable $TMPDIR (15-bit $RANDOM is guessable) and would
+    # NOT reapply -m 700 to it — letting them read/tamper with gen/stash. The $$ stays in the
+    # template so the same-shell reap + dead-PID GC above still parse the PID out of the name.
+    _nh_run_dir=$(mktemp -d "$base/nighthawk-plugin-$$-XXXXXXXX" 2>/dev/null) || { _nh_run_dir=""; return 1; }
+    _nh_gen=0
+    printf '%s' 0 > "$_nh_run_dir/gen"
+}
+
+# Remove our run dir. GUARDED against an empty/foreign path so a bare `rm -rf "$var"` can never run
+# on an unset var. Backstop for crash/HUP/KILL is the next session's GC in _nh_state_init.
+_nh_cleanup() {
+    [[ -n "$_nh_run_dir" && "$_nh_run_dir" == */nighthawk-plugin-* ]] && rm -rf -- "$_nh_run_dir"
+}
+
+# Bump the generation: in-process counter + a fork-free write-through to the `gen` file (plain
+# `printf >`, NOT temp+mv — do NOT "fix" with mv, which adds a per-keystroke fork). The staleness
+# guarantee is NOT write atomicity: a torn read CAN momentarily equal a PRIOR complete gen value
+# (e.g. 9->10 flushes "1" before "0", briefly matching a still-live gen0=1 worker). It's safe only
+# because any worker holding that older gen0 was debounce-cancelled many keystrokes earlier — so a
+# torn value can match a worker that has already exited. INVARIANT: if worker lifetime ever grows
+# past the debounce (a retry loop, a longer post-IPC window), this false-match reopens; switch to an
+# atomic mv-based gen write then. The single gen mutator, so var and file can't skew. Called once
+# per bound keystroke, before guards.
+_nh_bump_gen() {
+    [[ -n "$_nh_run_dir" ]] || return 0
+    _nh_gen=$(( _nh_gen + 1 ))
+    printf '%s' "$_nh_gen" > "$_nh_run_dir/gen"
+}
+
+# --- The ONLY /dev/tty sink ---
+# Both the foreground clear and the worker paint route through here, so the flock escape hatch (if
+# interleave corruption ever shows under fast typing) lives in ONE place: wrap the write in
+#   { flock 9; printf '%s' "$1" >/dev/tty; } 9>"$_nh_run_dir/lock"
+# (flock auto-creates the lockfile via the redirect — no reserved file needed). v1 ships no flock.
+_nh_tty_write() {
+    printf '%s' "$1" > /dev/tty 2>/dev/null
+}
+
+# --- Ghost clear ---
+# UNCONDITIONAL ESC[0J (clear to end of SCREEN, so a wrapped ghost is fully erased) + drop the
+# stash so a stale suggestion can never be accepted after the ghost is gone. No presence guard:
+# the foreground can't know the worker's paint length, and the clear is cheap enough to always
+# emit. Does NOT bump the generation (keystroke handlers bump separately).
+_nh_clear_ghost() {
+    _nh_tty_write "${_nh_esc}[s${_nh_esc}[0J${_nh_esc}[u"
+    [[ -n "$_nh_run_dir" ]] && rm -f "$_nh_run_dir/stash"
+}
+
+# --- Daemon auto-start (best-effort, detached) ---
+# Spawned in a background subshell so it never blocks the keystroke. The caller's backoff
+# prevents re-spawning every keystroke when `nh` is missing or the daemon won't come up.
+_nh_ensure_daemon() {
+    command -v nh >/dev/null 2>&1 && ( nh start >/dev/null 2>&1 & )
+}
+
+# --- Dispatch (foreground, NON-BLOCKING — Session 3) ---
+# Clear the ghost, bump the generation (a changed buffer/cursor makes any in-flight worker's
+# suggestion stale, so invalidating it is correct), run the cheap foreground guards, then
+# fire-and-forget ONE worker. The `( ( … ) & )` double-subshell backgrounds inside a subshell
+# where job control is OFF, so no `[n] pid` notification corrupts the line. Nothing here blocks
+# the keystroke. EOL invariant: READLINE_POINT (a BYTE offset) must equal the buffer's BYTE length
+# (never ${#buffer}, a char count under UTF-8). A missing socket arms a 5s backoff (the present-
+# but-hung case just costs one off-thread worker that eats socat -t3 — never a freeze).
+_nh_dispatch() {
+    local buffer=$READLINE_LINE
+    _nh_clear_ghost
+    _nh_bump_gen
+    [[ -n "$_nh_run_dir" ]] || return 0
+    [[ ${#buffer} -ge 2 ]] || return 0
+    local blen_bytes
+    blen_bytes=$(_nh_eol_bytes "$buffer")
+    (( READLINE_POINT == blen_bytes )) || return 0
+    local now=${EPOCHSECONDS:-$(date +%s)}
+    (( now < _nh_backoff_until )) && return 0
+    if [[ ! -S "$NIGHTHAWK_SOCKET" ]]; then
+        _nh_backoff_until=$(( now + 5 ))
+        _nh_ensure_daemon
+        return 0
+    fi
+    local gen0=$_nh_gen
+    ( ( _nh_worker "$gen0" "$buffer" "$blen_bytes" ) & )
+}
+
+# --- Worker (background subshell; inherits all _nh_* fns + state vars) ---
+# Sleeps the debounce, double-checks the generation (debounce-cancel), queries the daemon, runs the
+# pure pipeline (which enforces the control-char + range guards — the security backstop), re-checks
+# the generation immediately before any screen write, then PAINTS BEFORE STASHING so accept can
+# never fire on an unseen ghost: if the worker dies between paint and stash the user merely saw a
+# ghost with no stash, and accept no-ops (ghost clears on the next key). Every spawn is preceded by
+# _nh_bump_gen, so each worker has a unique gen0 and same-gen double-stash is unreachable.
+_nh_worker() {
+    local gen0=$1 buf=$2 cur=$3
+    sleep "$_nh_debounce_sec"
+    [[ "$(cat "$_nh_run_dir/gen" 2>/dev/null)" == "$gen0" ]] || return 0
+    local req resp
+    req=$(_nh_build_request "$buf" "$cur" "$PWD")
+    # head -n1 closes after one line; socat then takes SIGPIPE and exits (stderr suppressed).
+    resp=$(printf '%s\n' "$req" | socat -t3 - "UNIX-CONNECT:$NIGHTHAWK_SOCKET" 2>/dev/null | head -n1)
+    [[ -n "$resp" ]] || return 0
+    local out
+    out=$(_nh_compute_suggestion "$buf" "$resp")
+    [[ -n "$out" ]] || return 0
+    # Post-IPC staleness AND last-chance ENOENT (teardown) check, immediately before any write.
+    [[ "$(cat "$_nh_run_dir/gen" 2>/dev/null)" == "$gen0" ]] || return 0
+    local kind display bstart bend text
+    IFS=$'\t' read -r kind display bstart bend text <<<"$out"
+    # (a) PAINT first (folds in the retired _nh_render_ghost — single tty sink). The display field's
+    # load-bearing leading space (" -> text", or a suffix that starts with a space) is preserved.
+    _nh_tty_write "${_nh_esc}[s${_nh_esc}[90m${display}${_nh_esc}[0m${_nh_esc}[u"
+    # (b) then STASH atomically (same-dir temp + mv => rename is atomic; off-thread, fork is fine).
+    printf '%s\t%s\t%s\t%s' "$gen0" "$bstart" "$bend" "$text" > "$_nh_run_dir/.stash.$BASHPID" 2>/dev/null \
+        && mv -f "$_nh_run_dir/.stash.$BASHPID" "$_nh_run_dir/stash" 2>/dev/null
+}
+
+# --- Per-keystroke insert + trigger ---
+# bash has no self-insert widget under `bind -x`, so each printable key is rebound to insert its
+# own char then dispatch. The insert lives in a SEPARATE function under `local LC_ALL=C` so the
+# byte-domain slice indexes READLINE_POINT (a byte offset) correctly around any multibyte content,
+# and the C locale can't leak into the UTF-8 char math elsewhere. All bound chars are 1-byte ASCII.
+_nh_insert_byte() {
+    local LC_ALL=C
+    READLINE_LINE="${READLINE_LINE:0:READLINE_POINT}$1${READLINE_LINE:READLINE_POINT}"
+    (( READLINE_POINT += ${#1} ))
+}
+_nh_self_insert() {
+    _nh_insert_byte "$1"
+    _nh_dispatch
+}
+
+# --- Backspace ---
+# `bind -x` can't delegate to native backward-delete-char, so deletion is reimplemented in the CHAR
+# domain so a multibyte tail (é=2B, →=3B) is removed WHOLE. The rebuild slice runs in the ambient
+# UTF-8 locale; only the byte re-measure for READLINE_POINT flips to C (isolated in _nh_char_to_byte).
+# Then _nh_dispatch (which clears the ghost + bumps the generation) re-queries.
+_nh_bdelete_byte() {
+    local LC_ALL=C
+    READLINE_LINE="${READLINE_LINE:0:READLINE_POINT-1}${READLINE_LINE:READLINE_POINT}"
+    (( READLINE_POINT -= 1 ))
+}
+_nh_backward_delete() {
+    (( READLINE_POINT > 0 )) || { _nh_dispatch; return 0; }
+    local pchar
+    pchar=$(_nh_byte_to_char "$READLINE_LINE" "$READLINE_POINT")
+    if (( pchar > 0 )); then
+        READLINE_LINE="${READLINE_LINE:0:pchar-1}${READLINE_LINE:pchar}"
+        READLINE_POINT=$(_nh_char_to_byte "$READLINE_LINE" $(( pchar - 1 )))
+    else
+        _nh_bdelete_byte
+    fi
+    _nh_dispatch
+}
+
+# --- Accept precondition (single source of truth) ---
+# True iff a live stash exists AND the cursor is at EOL — the gate both accept-key handlers
+# (_nh_forward_or_accept / _nh_tab_widget) check before delegating to _nh_accept, which then
+# RE-validates everything authoritatively (and clears on any reject). Centralized here so the two
+# callers can't drift in how they test stash-presence + EOL. Returns 1 (not-ready) on a no-op source
+# where _nh_run_dir is unset, so the live helpers stay inert under the unit harness.
+_nh_stash_ready() {
+    [[ -n "$_nh_run_dir" && -f "$_nh_run_dir/stash" ]] || return 1
+    local eol; eol=$(_nh_eol_bytes "$READLINE_LINE")
+    (( READLINE_POINT == eol ))
+}
+
+# --- Accept (byte-domain splice, file-driven) ---
+# Read the accept payload from the `stash` FILE (the worker wrote it cross-process), revalidate
+# against LIVE state, then splice in the byte domain. Defenses, in order: stash must exist; its
+# `sgen` must equal the live generation (else stale -> clear); range must be digits; control-char
+# re-guard (the NON-NEGOTIABLE backstop against a planted-newline auto-submit / ESC hijack); EOL
+# re-check (a stash can outlive an unbound cursor move); live byte-bounds re-check. Byte domain
+# throughout under `local LC_ALL=C` (bstart/bend and READLINE_POINT are all byte offsets, so NO
+# char<->byte conversion — the worker's pipeline already validated code-point boundaries).
+_nh_accept() {
+    # Re-tests stash presence (not via _nh_stash_ready) ON PURPOSE: _nh_accept is the authoritative
+    # gate and must stand alone — the unit harness and any future caller invoke it directly without
+    # the caller-side _nh_stash_ready pre-check. The EOL re-check below is likewise independent.
+    [[ -n "$_nh_run_dir" && -f "$_nh_run_dir/stash" ]] || return 0
+    local sgen bstart bend text
+    IFS=$'\t' read -r sgen bstart bend text < "$_nh_run_dir/stash"
+    [[ "$sgen" == "$_nh_gen" ]] || { _nh_clear_ghost; return 0; }
+    [[ "$bstart" =~ ^[0-9]+$ && "$bend" =~ ^[0-9]+$ ]] || return 0
+    _nh_has_ctrl_char "$text" && { _nh_clear_ghost; return 0; }
+    local eol; eol=$(_nh_eol_bytes "$READLINE_LINE")
+    # Clear on the off-EOL reject too (a stash can outlive an UNBOUND cursor move that didn't clear);
+    # matching the stale-gen / ctrl-char branches above so no reject path can strand a painted ghost.
+    (( READLINE_POINT == eol )) || { _nh_clear_ghost; return 0; }
+    _nh_clear_ghost
+    local LC_ALL=C
+    local blen=${#READLINE_LINE}
+    # Self-contained range guard: also bound bstart (not just bend) so accept never trusts the
+    # cross-process worker's [bstart,bend) ordering. Today bend>=bstart is enforced upstream, but
+    # re-checking here keeps the splice correct even against a hand-tampered stash.
+    (( bend < bstart || bstart > blen || bend > blen )) && return 0
+    local before=${READLINE_LINE:0:bstart} after=${READLINE_LINE:bend}
+    READLINE_LINE="${before}${text}${after}"
+    READLINE_POINT=$(( ${#before} + ${#text} ))
+}
+
+# --- RightArrow / Ctrl-F: accept at EOL, else move forward one char ---
+# Presence is now stash-file existence (the in-process _nh_sug_* globals are retired). At EOL with a
+# live stash -> accept; otherwise drop the ghost, invalidate in-flight workers (bump), and
+# reimplement forward-char (advance one CHAR, multibyte-safe). At EOL with no stash this is a no-op.
+_nh_forward_or_accept() {
+    if _nh_stash_ready; then
+        _nh_accept
+        return 0
+    fi
+    _nh_clear_ghost
+    _nh_bump_gen
+    local cchar
+    cchar=$(_nh_byte_to_char "$READLINE_LINE" "$READLINE_POINT")
+    (( cchar >= 0 && cchar < ${#READLINE_LINE} )) && \
+        READLINE_POINT=$(_nh_char_to_byte "$READLINE_LINE" $(( cchar + 1 )))
+}
+
+# --- Tab: accept the suggestion (OPT-IN, bash-only; bound only when _nh_tab_accept=1) ---
+# Accepts a live ghost at EOL; otherwise a NO-OP. bash's `bind -x` cannot fall back to native
+# readline completion (unlike zsh's `zle expand-or-complete` / PowerShell's TabCompleteNext), so
+# when this is enabled and no suggestion is showing, Tab does nothing — the documented tradeoff of
+# turning it on. Right arrow + Ctrl-F remain accept keys whether or not this is enabled.
+_nh_tab_widget() {
+    _nh_stash_ready && _nh_accept
+}
+
+# --- Bound cursor MOTIONS: clear the ghost + invalidate in-flight workers, then move ---
+# Closes the "worker paints mid-line after a cursor move" regression for the common keys. PURE
+# motions only (no buffer mutation, no kill-ring) so reimplementing them is trivially correct.
+# Ctrl-K/U/W are NOT bound — a bash reimplementation can't populate the kill-ring, so Ctrl-Y would
+# break; they stay native and fall into the documented "unbound key may linger a ghost" bucket.
+_nh_cursor_left() {
+    _nh_clear_ghost; _nh_bump_gen
+    local cchar
+    cchar=$(_nh_byte_to_char "$READLINE_LINE" "$READLINE_POINT")
+    (( cchar > 0 )) && READLINE_POINT=$(_nh_char_to_byte "$READLINE_LINE" $(( cchar - 1 )))
+}
+_nh_cursor_home() { _nh_clear_ghost; _nh_bump_gen; READLINE_POINT=0; }
+_nh_cursor_end()  { _nh_clear_ghost; _nh_bump_gen; READLINE_POINT=$(_nh_eol_bytes "$READLINE_LINE"); }
+
+# --- Escape: dismiss the ghost (and invalidate any in-flight worker) ---
+_nh_dismiss() {
+    _nh_clear_ghost
+    _nh_bump_gen
+}
+
+# --- Bind one printable char to insert-and-suggest ---
+# Quoting is the hazard (the curated set includes " \ ` $ ' and space). Only " and \ need readline
+# keyseq escaping; the ARGUMENT half is %q-quoted so the char reaches _nh_self_insert intact
+# regardless of shell metacharacters.
+#
+# The KEYSEQ escaping uses a `case`, NOT ${seq//\\/\\\\}: as of bash 5.1 the REPLACEMENT half of a
+# ${//} expansion processes backslashes, so the four-backslash replacement collapses back to a
+# single \ — leaving the `\` key unbound AND printing `bind: no closing '"'` at every interactive
+# startup/re-source. The case sidesteps that layer entirely (verified on bash 5.2).
+_nh_bind_insert() {
+    local seq q
+    case $1 in
+        '\') seq='\\' ;;     # readline keyseq for a literal backslash key
+        '"') seq='\"' ;;     # readline keyseq for a literal double-quote key
+        *)   seq=$1   ;;
+    esac
+    printf -v q '%q' "$1"
+    bind -x "\"${seq}\": _nh_self_insert ${q}"
+}
+
+# --- Key bindings + state init (interactive shells only) ---
+# Guarded so a non-interactive source (the unit harness) has zero side effects: no run dir, no
+# trap, no bindings, and every live helper is a no-op on the unset _nh_run_dir. Re-sourcing is
+# safe: _nh_state_init picks a fresh nonce'd dir (orphaning prior-load workers) and `bind -x`
+# rebinding is idempotent. The function definitions above are OUTSIDE this guard so the harness can
+# unit-test _nh_accept etc. with an injected _nh_run_dir.
+if [[ $- == *i* ]] && (( BASH_VERSINFO[0] >= 4 )); then
+    _nh_state_init
+    # Chain (don't clobber) any pre-existing EXIT trap; idempotent on re-source. HUP/KILL/crash are
+    # covered by the next session's dead-PID GC in _nh_state_init.
+    _nh_prev_exit=$(trap -p EXIT)
+    case "$_nh_prev_exit" in
+        *_nh_cleanup*) : ;;                                   # already chained (re-source)
+        "") trap '_nh_cleanup' EXIT ;;
+        *)  # Wrap the prior trap in a function rather than string-splicing its body into a fresh
+            # `trap` command. `trap -p` renders an embedded single quote as the '\'' idiom, escaped
+            # RELATIVE TO the outer quotes; stripping those outer quotes orphans the escaping and a
+            # re-quote yields `unexpected EOF looking for matching '` on exit — silently killing BOTH
+            # the user's trap AND our cleanup. Instead strip only the `trap -- `/` EXIT` command
+            # wrapper (body quoting left intact) and `eval` the body inside the wrapper: eval's own
+            # quote-removal recovers the original command faithfully, quotes and all.
+            _nh_prev_exit=${_nh_prev_exit#trap -- }
+            _nh_prev_exit=${_nh_prev_exit% EXIT}
+            eval "_nh_run_prev_exit() { eval ${_nh_prev_exit}; }"
+            trap '_nh_cleanup; _nh_run_prev_exit' EXIT ;;
+    esac
+    unset _nh_prev_exit
+
+    # Printable ASCII -> insert + dispatch. Curated set; Tab and control keys are intentionally
+    # absent so native Tab-completion (and fzf/atuin/menu-complete) is left fully intact.
+    for _nh_c in {a..z} {A..Z} {0..9} ' ' '-' '_' '.' '/' '\' ':' '~' '=' '+' '@' '#' '%' \
+        '^' '&' '*' ',' ';' '!' '|' "'" '"' '(' ')' '[' ']' '{' '}' '<' '>' '?' '$' '`'; do
+        _nh_bind_insert "$_nh_c"
+    done
+    unset _nh_c
+
+    # Backspace (both common encodings) -> char-domain delete + re-dispatch.
+    bind -x '"\C-?": _nh_backward_delete'
+    bind -x '"\C-h": _nh_backward_delete'
+
+    # Accept keys: RightArrow (\e[C + application-mode \eOC) and Ctrl-F. Accept at EOL, else move.
+    bind -x '"\e[C": _nh_forward_or_accept'
+    bind -x '"\eOC": _nh_forward_or_accept'
+    bind -x '"\C-f": _nh_forward_or_accept'
+
+    # Tab -> accept (OPT-IN, default off; `tab_accept = true` / NIGHTHAWK_TAB_ACCEPT=1). Enabling it
+    # GIVES UP native Tab-completion (bind -x can't delegate to it), so it's off by default — Right
+    # arrow + Ctrl-F always accept. \C-i is Tab.
+    if (( _nh_tab_accept )); then
+        bind -x '"\C-i": _nh_tab_widget'
+    fi
+
+    # Cursor MOTIONS -> clear ghost + invalidate in-flight workers, then move (closes the mid-line
+    # paint regression). Left (\e[D/\eOD), Home (\e[H/\eOH/\e[1~/\C-a), End (\e[F/\eOF/\e[4~/\C-e).
+    bind -x '"\e[D": _nh_cursor_left'
+    bind -x '"\eOD": _nh_cursor_left'
+    bind -x '"\e[H": _nh_cursor_home'
+    bind -x '"\eOH": _nh_cursor_home'
+    bind -x '"\e[1~": _nh_cursor_home'
+    bind -x '"\C-a": _nh_cursor_home'
+    bind -x '"\e[F": _nh_cursor_end'
+    bind -x '"\eOF": _nh_cursor_end'
+    bind -x '"\e[4~": _nh_cursor_end'
+    bind -x '"\C-e": _nh_cursor_end'
+
+    # Escape -> dismiss the ghost. Coexists with the \e[…/\eO… arrow sequences via readline's
+    # longer-match rule (a real arrow's bytes arrive together and win); only a LONE Esc waits out
+    # keyseq-timeout. Highest-risk binding — verify arrows still work in manual testing.
+    bind -x '"\e": _nh_dismiss'
+
+    # Enter -> clear the ghost, then submit. `bind -x` can't call accept-line, so this is a macro:
+    # run the clear helper (bound to an obscure sequence) then emit \C-j (newline), still bound to
+    # native accept-line, which submits the real READLINE_LINE. \C-j (not \C-m) so the macro can't
+    # re-trigger itself. The clear now fires UNCONDITIONALLY on every Enter (even with no ghost) —
+    # verify no stray artifact on submit (manual-test item).
+    bind -x '"\C-x\C-g": _nh_clear_ghost'
+    bind '"\C-m": "\C-x\C-g\C-j"'
+
+    # Defensive: drop any ghost state at load (e.g. re-source while a ghost was on screen).
+    _nh_clear_ghost
+fi

--- a/shells/nighthawk.bash
+++ b/shells/nighthawk.bash
@@ -192,11 +192,19 @@ _nh_build_request() {
 
 # --- Response parse ---
 # Emits eval-able assignments for the first suggestion: text / replace_start / replace_end
-# (jq @sh-quoted) and a bare diff_ops_present 0|1 flag. The caller MUST declare these as
-# locals (defaulted) BEFORE `eval "$(_nh_parse_response ...)"` so a jq failure (malformed
-# JSON, swallowed by 2>/dev/null) leaves them empty rather than stale from a prior call.
-# Only suggestions[0] is used, matching the zsh/PowerShell plugins.
+# (jq @sh-quoted) and a bare diff_ops_present 0|1 flag. SELF-DEFAULTING: all four assignments
+# are emitted empty/0 FIRST (a fixed literal outside jq), so even a jq crash — malformed JSON
+# swallowed by 2>/dev/null, producing no output at all — still resets every field rather than
+# leaving it stale from a prior call. On success the jq assignments that follow (after the
+# `;`) override the defaults. The caller therefore only needs to declare these `local` for
+# scoping; it need not pre-default them. Only suggestions[0] is used, matching zsh/PowerShell.
+# diff_ops is reduced to a PRESENCE flag (not extracted) because bash is hint-only — there is
+# no inline-diff renderer (see CLAUDE.md / the no-inline-diff decision). A future session that
+# adds inline-diff rendering MUST also port zsh's separate control-char guard over the per-op
+# `ch` bytes (zsh _nh_handle_response); those bytes bypass the `_nh_has_ctrl_char "$text"`
+# check and would otherwise reintroduce the newline/ESC injection vector this plugin closes.
 _nh_parse_response() {
+    printf "text='' replace_start='' replace_end='' diff_ops_present=0;"
     printf '%s' "$1" | jq -r '
         if (.suggestions | length) > 0 then
             "text=" + (.suggestions[0].text | @sh)
@@ -212,16 +220,26 @@ _nh_parse_response() {
 
 # --- Prefix-vs-hint decision ---
 # Pure. Echoes a tagged, display-ready payload for the S2 renderer to dispatch on:
-#   ghost<TAB><suffix>   true prefix match — render <suffix> as ghost after the cursor
-#   hint<TAB> -> <text>  replacement / fuzzy — render as a hint
-#   (empty)              nothing to show
+#   ghost<TAB><suffix>     true prefix match — render <suffix> as ghost after the cursor
+#   hint<TAB> -> <text>    replacement / fuzzy — render as a hint
+#   (empty)                nothing to show
+# S2 PARSE CONTRACT: split on the FIRST TAB (e.g. `IFS=$'\t' read -r tag payload`). The
+# hint payload's LEADING SPACE is load-bearing — it is part of the rendered prefix
+# (" -> <text>"), matching the leading space the zsh/PS renderers prepend; S2 MUST emit
+# <payload> verbatim and never trim or word-split it. The ghost branch prepends no separator
+# (its payload is the raw suffix, which may itself legitimately begin with a space).
 # bash follows the PowerShell hint-only model: a fuzzy match (diff_ops present) always
 # renders as a hint; there is no inline-diff renderer. <rstart_chars> is the CHAR-domain
 # replace_start (already byte->char converted). Self-guards rstart so a -1 from a failed
 # conversion can never reach the ${buffer:rstart:...} subscript across the S2/S3 seam.
 # <snapshot_buffer> MUST be the same buffer snapshot whose bytes fed _nh_build_request and
-# the offset conversion — never live READLINE_LINE. Typed length is derived from the buffer
-# length because the suggest path only ever fires with the cursor at end-of-line.
+# the offset conversion — never live READLINE_LINE.
+# CURSOR INVARIANT: unlike the zsh/PS siblings (which compute typed_len = cursor - rstart),
+# this derives typed_len = ${#buffer} - rstart, i.e. it assumes the cursor sits at
+# end-of-line. That holds because the suggest path only ever fires at EOL, so no cursor
+# parameter is taken. The S3 caller MUST preserve that invariant (snapshot the buffer with
+# cursor == buffer end); if mid-line suggestions are ever added, this needs an explicit
+# cursor argument to match the siblings.
 _nh_decide_render() {
     local buffer=$1 text=$2 rstart=$3 diff_present=$4
     [[ -n "$text" ]] || return 0
@@ -249,7 +267,9 @@ _nh_decide_render() {
 # S3 async path can drive it with a canned reply; S2 only adds the actual render of the tag.
 _nh_compute_suggestion() {
     local buffer=$1 response=$2
-    local text='' replace_start='' replace_end='' diff_ops_present=0
+    # _nh_parse_response is self-defaulting (resets all four even on a jq failure), so these
+    # are declared local purely for scoping — no pre-defaulting needed.
+    local text replace_start replace_end diff_ops_present
     eval "$(_nh_parse_response "$response")"
     [[ -n "$text" ]] || return 0
     # Fail-closed: drop any suggestion carrying a control char before it can be rendered
@@ -260,6 +280,13 @@ _nh_compute_suggestion() {
     fi
     # Reject a non-integer range (e.g. "null" from a malformed reply) before arithmetic.
     [[ "$replace_start" =~ ^[0-9]+$ && "$replace_end" =~ ^[0-9]+$ ]] || return 0
+    # Normalize to base-10 so a zero-padded offset (e.g. "08"/"09" from a misbehaving or
+    # hostile daemon) can't trip octal parsing inside the converters' `(( ))` arithmetic —
+    # which fails closed but spews "value too great for base" to stderr on every keystroke in
+    # the live path. Mirrors the debounce 10# guard. The ^[0-9]+$ check above guarantees a
+    # non-negative digit string, so 10# here is safe (no sign/overflow surprise).
+    replace_start=$(( 10#$replace_start ))
+    replace_end=$(( 10#$replace_end ))
     # Protocol byte offsets -> char indices against the snapshot buffer. Fail closed if
     # either is out of range or splits a multibyte char.
     local rstart rend

--- a/shells/tests/helpers.test.bash
+++ b/shells/tests/helpers.test.bash
@@ -33,15 +33,24 @@ fi
 source "$_nh_plugin"
 
 # Structural check: the helpers must exist after sourcing (guards a rename / missing deps).
+# Includes the Session-3 cross-process helpers (_nh_ms_to_sec pure; _nh_bump_gen/_nh_accept etc.
+# defined OUTSIDE the interactive guard so they're unit-testable with an injected _nh_run_dir).
 for fn in _nh_load_config _nh_log _nh_has_ctrl_char _nh_byte_to_char _nh_char_to_byte \
           _nh_json_escape _nh_build_request _nh_parse_response _nh_decide_render \
-          _nh_compute_suggestion; do
+          _nh_compute_suggestion _nh_ms_to_sec _nh_bump_gen _nh_accept _nh_forward_or_accept \
+          _nh_tab_widget _nh_dismiss _nh_stash_ready; do
     if ! declare -F "$fn" >/dev/null; then
         echo "helpers.test.bash: FAIL — $fn not defined after sourcing plugin (renamed? deps missing?)" >&2
         rm -rf "$_nh_tmpcfg"
         exit 2
     fi
 done
+
+# The Session-3 live layer writes the ghost to /dev/tty via _nh_tty_write. Stub it to a no-op so
+# the accept/clear/motion tests don't spray ANSI at (or fail on the absence of) a real terminal —
+# the analogue of the `bind` shadow above. The cross-process gen/stash FILES are exercised for
+# real against a scaffolded temp _nh_run_dir; only the tty paint is stubbed.
+_nh_tty_write() { :; }
 
 # --- Assertion harness ---
 _nh_pass=0
@@ -97,6 +106,12 @@ check "c2b 3"  6  "$(_nh_char_to_byte "$S" 3)"
 check "c2b 5"  12 "$(_nh_char_to_byte "$S" 5)"
 check "c2b past-end clamps" 12 "$(_nh_char_to_byte "$S" 99)"
 check "c2b negative -> 0"    0 "$(_nh_char_to_byte "$S" -3)"
+
+# --- _nh_eol_bytes: byte length of the whole string (= byte offset of EOL). Robust even on a
+# libc that miscounts astral chars, since it measures the full string regardless of char count. ---
+check "eol_bytes ascii"     12 "$(_nh_eol_bytes "$A")"
+check "eol_bytes multibyte" 12 "$(_nh_eol_bytes "$S")"
+check "eol_bytes empty"      0 "$(_nh_eol_bytes "")"
 
 # --- round-trip over every boundary ---
 for i in 0 1 2 3 5; do
@@ -194,11 +209,20 @@ check "decide hint (diff)" $'hint\t -> git status' \
 check "decide guards rstart=-1" "" "$(_nh_decide_render 'git' 'git status' -1 0)"
 # Empty text -> empty.
 check "decide empty text" "" "$(_nh_decide_render 'git' '' 0 0)"
+# Boundary: buffer already equals the full suggestion (typed_len == ${#text}) -> nothing to ghost.
+# Guards the `typed_len < ${#text}` comparison from a future `<` -> `<=` regression (empty ghost).
+check "decide empty when fully typed" "" "$(_nh_decide_render 'git status' 'git status' 0 0)"
+# Boundary: rstart past the buffer end (a stale/garbage offset) -> guarded to empty, never a bad
+# ${buffer:rstart:...} subscript.
+check "decide empty when rstart>blen" "" "$(_nh_decide_render 'git' 'git status' 99 0)"
 
-# End-to-end pipeline through parse + reject + convert + validate + decide:
-check "pipeline ghost" $'ghost\t status' \
+# End-to-end pipeline through parse + reject + convert + validate + decide. Output is now the
+# 5-field record <kind>\t<display>\t<bstart>\t<bend>\t<text>: the display tag plus the daemon's
+# BYTE range + replacement text for the accept path. (bstart/bend equal the char offsets here
+# because the buffers are ASCII.)
+check "pipeline ghost" $'ghost\t status\t0\t3\tgit status' \
     "$(_nh_compute_suggestion 'git' '{"suggestions":[{"text":"git status","replace_start":0,"replace_end":3}]}')"
-check "pipeline hint (divergent)" $'hint\t -> git status' \
+check "pipeline hint (divergent)" $'hint\t -> git status\t0\t3\tgit status' \
     "$(_nh_compute_suggestion 'gti' '{"suggestions":[{"text":"git status","replace_start":0,"replace_end":3}]}')"
 # Control char in suggestion -> rejected (no output).
 check "pipeline rejects ctrl-char suggestion" "" \
@@ -209,8 +233,210 @@ check "pipeline rejects null range" "" \
 # Zero-padded offset ("09") from a misbehaving daemon: base-10 normalization must parse it as
 # 9 (not trip octal in the converters). Before the 10# guard this errored to stderr and the
 # suggestion was dropped (empty); now it resolves to the correct ghost suffix.
-check "pipeline base-10 normalizes 09" $'ghost\ting' \
+check "pipeline base-10 normalizes 09" $'ghost\ting\t0\t9\techo testing' \
     "$(_nh_compute_suggestion 'echo test' '{"suggestions":[{"text":"echo testing","replace_start":"00","replace_end":"09"}]}' 2>/dev/null)"
+# Multibyte: proves the record carries the daemon's BYTE offsets while the internal prefix
+# decision used CHAR offsets. buffer "café" is 5 bytes / 4 chars; replace [0,5) (bytes) with
+# "café list" -> ghost suffix " list", and the record's bstart/bend are 0/5 (BYTES, not 0/4).
+# The é is built via $'...' into VARIABLES first — a literal \xc3\xa9 inside a "..." JSON
+# string is NOT interpreted by bash, so jq would reject the bogus \x escape (empty output).
+_mb_buf=$'caf\xc3\xa9'
+_mb_txt=$'caf\xc3\xa9 list'
+check "pipeline multibyte carries byte offsets" $'ghost\t list\t0\t5\tcaf\xc3\xa9 list' \
+    "$(_nh_compute_suggestion "$_mb_buf" "{\"suggestions\":[{\"text\":\"$_mb_txt\",\"replace_start\":0,\"replace_end\":5}]}")"
+
+# ======================================================================================
+# 5-field tag parse (the split _nh_suggest performs). IFS must be EXACTLY a tab so the
+# display field's load-bearing LEADING SPACE survives — the whole reason hint/ghost payloads
+# carry it. A default-IFS read would strip it and mis-render. This asserts the contract the
+# render+accept dispatch depends on.
+# ======================================================================================
+tagparse() {  # tagparse <record> -> sets k/d/bs/be/t from the 5 tab fields
+    IFS=$'\t' read -r k d bs be t <<< "$1"
+}
+tagparse $'ghost\t status\t0\t3\tgit status'
+check "tagparse kind"                        "ghost"      "$k"
+check "tagparse display keeps leading space" " status"    "$d"
+check "tagparse bstart"                      "0"          "$bs"
+check "tagparse bend"                        "3"          "$be"
+check "tagparse text"                        "git status" "$t"
+tagparse $'hint\t -> git status\t0\t3\tgit status'
+check "tagparse hint display verbatim"       " -> git status" "$d"
+
+# ======================================================================================
+# Session-3 cross-process state: debounce derivation, gen file, stash serde, then the file-driven
+# accept gate. Scaffold a temp run dir (the interactive guard never ran, so _nh_run_dir is unset
+# and these helpers would otherwise no-op — that no-op IS the non-tty inertness guarantee). The
+# path is saved separately because the config-reload section below re-sources the plugin, which
+# resets _nh_run_dir="" — so final cleanup must use the saved copy.
+# ======================================================================================
+_nh_run_dir=$(mktemp -d); _nh_test_rundir="$_nh_run_dir"
+_nh_stash() { printf '%s\t%s\t%s\t%s' "$1" "$2" "$3" "$4" > "$_nh_run_dir/stash"; }
+
+# _nh_ms_to_sec: integer-ms -> fractional-seconds string splice. The 50->0.050 row is the
+# anti-10x-bug guard (a naive splice would yield 0.50 = 500ms); 0 floors to the 10ms minimum.
+check "ms_to_sec 200"         "0.200"  "$(_nh_ms_to_sec 200)"
+check "ms_to_sec 50 (no 10x)" "0.050"  "$(_nh_ms_to_sec 50)"
+check "ms_to_sec 1500"        "1.500"  "$(_nh_ms_to_sec 1500)"
+check "ms_to_sec 10000"       "10.000" "$(_nh_ms_to_sec 10000)"
+check "ms_to_sec 10"          "0.010"  "$(_nh_ms_to_sec 10)"
+check "ms_to_sec 0 -> floor"  "0.010"  "$(_nh_ms_to_sec 0)"
+
+# _nh_bump_gen: in-process counter and gen FILE move together (single mutator, monotonic).
+_nh_gen=0
+_nh_bump_gen; check "bump gen var 1" 1 "$_nh_gen"; check "bump gen file 1" 1 "$(cat "$_nh_run_dir/gen")"
+_nh_bump_gen; check "bump gen var 2" 2 "$_nh_gen"; check "bump gen file 2" 2 "$(cat "$_nh_run_dir/gen")"
+
+# Stash serde round-trip: the 4 tab fields survive, including a `text` with internal spaces.
+_nh_stash 3 0 5 "git commit -m"
+IFS=$'\t' read -r _sg _sb _se _st < "$_nh_run_dir/stash"
+check "stash gen field"         3               "$_sg"
+check "stash bstart field"      0               "$_sb"
+check "stash bend field"        5               "$_se"
+check "stash text keeps spaces" "git commit -m" "$_st"
+
+# ======================================================================================
+# Accept-splice (byte-domain, FILE-DRIVEN). _nh_accept reads the `stash` file, revalidates
+# sgen == _nh_gen + EOL + range + control-char against live READLINE_LINE/POINT, then splices the
+# [bstart,bend) BYTE range and parks the cursor (byte offset) at the end of the inserted text.
+# (Replaces the S2 globals-driven tests — the in-process _nh_sug_* stash is retired cross-process.)
+# ======================================================================================
+_nh_gen=5
+# Happy path: "git" + replace [0,3) with "git status" -> full token, cursor at byte 10.
+READLINE_LINE="git"; READLINE_POINT=3
+_nh_stash 5 0 3 "git status"
+_nh_accept
+check "accept splices full token"   "git status" "$READLINE_LINE"
+check "accept cursor at end (bytes)" "10"         "$READLINE_POINT"
+# Stale generation (sgen != live gen) -> rejected, buffer untouched.
+READLINE_LINE="git"; READLINE_POINT=3
+_nh_stash 4 0 3 "git status"
+_nh_accept
+check "accept rejects stale gen" "git" "$READLINE_LINE"
+# Off-EOL (cursor not at buffer end) -> rejected even with a fresh stash (a stash can outlive a move).
+# Also asserts the off-EOL reject DROPS the stash (the clear), so a stale ghost can't be re-accepted.
+READLINE_LINE="git log"; READLINE_POINT=3
+_nh_stash 5 0 3 "git log"
+_nh_accept
+check "accept rejects off-EOL" "git log" "$READLINE_LINE"
+check "accept off-EOL dropped the stash" "" "$([[ -f "$_nh_run_dir/stash" ]] && echo present)"
+# Inverted range (bstart > bend, e.g. from a tampered stash) -> fail closed, buffer untouched.
+READLINE_LINE="git"; READLINE_POINT=3
+_nh_stash 5 3 0 "X"
+_nh_accept
+check "accept bails on inverted range (bstart>bend)" "git" "$READLINE_LINE"
+# Out-of-range range (stale bend past end) -> fail closed, buffer untouched.
+READLINE_LINE="git"; READLINE_POINT=3
+_nh_stash 5 0 99 "X"
+_nh_accept
+check "accept bails on out-of-range range" "git" "$READLINE_LINE"
+# No stash file (no live suggestion) -> no-op.
+rm -f "$_nh_run_dir/stash"
+READLINE_LINE="git"; READLINE_POINT=3
+_nh_accept
+check "accept bails on missing stash" "git" "$READLINE_LINE"
+# Multibyte splice: "café" (5 bytes) replace [0,5) with "café list" -> cursor parks at byte 10.
+READLINE_LINE=$'caf\xc3\xa9'; READLINE_POINT=5
+_nh_stash 5 0 5 $'caf\xc3\xa9 list'
+_nh_accept
+check "accept multibyte splice"         $'caf\xc3\xa9 list' "$READLINE_LINE"
+check "accept multibyte cursor (bytes)"  10                 "$READLINE_POINT"
+# Control-char defense (the security backstop), two complementary properties:
+# (1) A planted NON-newline C0 char (ESC) survives `read` and is rejected by _nh_has_ctrl_char.
+READLINE_LINE="rm "; READLINE_POINT=3
+_nh_stash 5 0 3 $'rm\x1b-rf'
+_nh_accept
+check "accept rejects ESC-bearing stash" "rm " "$READLINE_LINE"
+# (2) A planted NEWLINE (the auto-submit RCE vector) can NEVER reach the buffer: `read` terminates
+# the field at the newline, so the spliced READLINE_LINE is single-line — no accept-line trigger.
+# (In production the worker's pipeline already rejected any control char upstream; this is the
+# cross-process belt-and-suspenders that makes the newline vector structurally impossible.)
+READLINE_LINE="rm "; READLINE_POINT=3
+_nh_stash 5 0 3 $'rm -rf /\n'
+_nh_accept
+case "$READLINE_LINE" in *$'\n'*) _nl=yes ;; *) _nl=no ;; esac
+check "accept: planted newline never reaches buffer" "no" "$_nl"
+
+# ======================================================================================
+# Cursor-motion + delete edit logic (touch only READLINE_LINE/POINT + the stash/gen files, no real
+# tty — _nh_tty_write is stubbed above). _nh_dispatch is stubbed to a no-op so _nh_backward_delete's
+# trailing re-query can't attempt IPC (or spawn a daemon/worker) during the test.
+# ======================================================================================
+_nh_dispatch() { :; }
+
+# forward_or_accept, NO stash -> reimplements forward-char (advance one CHAR, byte-correct).
+rm -f "$_nh_run_dir/stash"
+READLINE_LINE=$'caf\xc3\xa9'; READLINE_POINT=2
+_nh_forward_or_accept
+check "forward moves one ascii char"            3 "$READLINE_POINT"
+READLINE_LINE=$'caf\xc3\xa9'; READLINE_POINT=3   # cursor before the 2-byte é
+_nh_forward_or_accept
+check "forward crosses multibyte char (3->5)"   5 "$READLINE_POINT"
+READLINE_LINE=$'caf\xc3\xa9'; READLINE_POINT=5   # at EOL, no stash
+_nh_forward_or_accept
+check "forward no-op at EOL without stash"       5 "$READLINE_POINT"
+# Live stash at EOL -> accept; off-EOL -> move (the EOL re-check), leaving the buffer intact.
+_nh_gen=7
+READLINE_LINE="git"; READLINE_POINT=3
+_nh_stash 7 0 3 "git status"
+_nh_forward_or_accept
+check "forward accepts at EOL with stash" "git status" "$READLINE_LINE"
+READLINE_LINE="git status"; READLINE_POINT=3      # cursor mid-line, stash live
+_nh_stash 7 0 3 "git status"
+_nh_forward_or_accept
+check "forward does NOT accept off-EOL"  "git status" "$READLINE_LINE"
+check "forward advanced cursor off-EOL"   4           "$READLINE_POINT"
+
+# _nh_tab_widget (opt-in Tab accept): same stash+EOL gate as forward_or_accept via _nh_stash_ready,
+# but accept-or-NOOP (no forward-char fallback). Covers the security-relevant opt-in accept path.
+_nh_gen=7
+READLINE_LINE="git"; READLINE_POINT=3
+_nh_stash 7 0 3 "git status"
+_nh_tab_widget
+check "tab accepts at EOL with stash" "git status" "$READLINE_LINE"
+READLINE_LINE="git status"; READLINE_POINT=3       # cursor mid-line, stash live -> no accept
+_nh_stash 7 0 3 "git status"
+_nh_tab_widget
+check "tab no-op off-EOL" "git status" "$READLINE_LINE"
+rm -f "$_nh_run_dir/stash"                         # no stash -> no-op (does NOT native-complete)
+READLINE_LINE="git"; READLINE_POINT=3
+_nh_tab_widget
+check "tab no-op without stash" "git" "$READLINE_LINE"
+
+# _nh_dismiss (Escape): drops the stash + bumps the generation, never touching the buffer.
+_nh_gen=7
+_nh_stash 7 0 3 "git status"
+READLINE_LINE="git"; READLINE_POINT=3
+_nh_dismiss
+check "dismiss dropped the stash" "" "$([[ -f "$_nh_run_dir/stash" ]] && echo present)"
+check "dismiss bumped the gen"    8    "$_nh_gen"
+check "dismiss left buffer alone" "git" "$READLINE_LINE"
+
+# Bound cursor MOTIONS (Left/Home/End): clear the ghost (drops the stash) + move, multibyte-safe.
+_nh_stash 7 0 3 "x"
+READLINE_LINE=$'caf\xc3\xa9'; READLINE_POINT=5
+_nh_cursor_left
+check "cursor_left crosses multibyte (5->3)" 3 "$READLINE_POINT"
+check "cursor_left dropped the stash" "" "$([[ -f "$_nh_run_dir/stash" ]] && echo present)"
+READLINE_LINE=$'caf\xc3\xa9'; READLINE_POINT=3
+_nh_cursor_home
+check "cursor_home to BOL" 0 "$READLINE_POINT"
+READLINE_LINE=$'caf\xc3\xa9'; READLINE_POINT=0
+_nh_cursor_end
+check "cursor_end to EOL (bytes)" 5 "$READLINE_POINT"
+
+# backward_delete removes a WHOLE codepoint (never half a multibyte char).
+READLINE_LINE=$'caf\xc3\xa9'; READLINE_POINT=5
+_nh_backward_delete
+check "backspace removes whole multibyte char" "caf" "$READLINE_LINE"
+check "backspace cursor after delete (bytes)"   3    "$READLINE_POINT"
+READLINE_LINE="git"; READLINE_POINT=3
+_nh_backward_delete
+check "backspace removes ascii char" "gi" "$READLINE_LINE"
+check "backspace ascii cursor"        2   "$READLINE_POINT"
+READLINE_LINE="git"; READLINE_POINT=0
+_nh_backward_delete
+check "backspace at pos 0 is a no-op" "git" "$READLINE_LINE"
 
 # ======================================================================================
 # Config: precedence (default < file < env) + debounce clamp. Re-sources the plugin under
@@ -219,12 +445,13 @@ check "pipeline base-10 normalizes 09" $'ghost\ting' \
 reload() { source "$_nh_plugin"; }   # re-runs config load + env override + clamp
 
 # 1. Defaults (empty temp config dir, env unset).
-unset NIGHTHAWK_HINT_ARROW NIGHTHAWK_DEBOUNCE_MS NIGHTHAWK_DEBUG
+unset NIGHTHAWK_HINT_ARROW NIGHTHAWK_DEBOUNCE_MS NIGHTHAWK_DEBUG NIGHTHAWK_TAB_ACCEPT
 rm -f "$_nh_tmpcfg/nighthawk/config.toml"
 reload
-check "cfg default arrow"    "->" "$_nh_hint_arrow"
-check "cfg default debounce" "200" "$_nh_debounce_ms"
-check "cfg default debug"    "0"  "$_nh_debug"
+check "cfg default arrow"      "->"  "$_nh_hint_arrow"
+check "cfg default debounce"   "200" "$_nh_debounce_ms"
+check "cfg default debug"      "0"   "$_nh_debug"
+check "cfg default tab_accept" "0"   "$_nh_tab_accept"
 
 # 2. File overrides default.
 mkdir -p "$_nh_tmpcfg/nighthawk"
@@ -236,17 +463,20 @@ hint_arrow = "XX"
 hint_arrow = "=>"
 debounce_ms = 350
 debug = true
+tab_accept = true
 TOML
 reload
-check "cfg file arrow"    "=>"  "$_nh_hint_arrow"
-check "cfg file debounce" "350" "$_nh_debounce_ms"
-check "cfg file debug"    "1"   "$_nh_debug"
+check "cfg file arrow"      "=>"  "$_nh_hint_arrow"
+check "cfg file debounce"   "350" "$_nh_debounce_ms"
+check "cfg file debug"      "1"   "$_nh_debug"
+check "cfg file tab_accept" "1"   "$_nh_tab_accept"
 
-# 3. Env overrides file.
-export NIGHTHAWK_HINT_ARROW=">>" NIGHTHAWK_DEBOUNCE_MS=99 NIGHTHAWK_DEBUG=1
+# 3. Env overrides file (tab_accept: file says true, env forces 0).
+export NIGHTHAWK_HINT_ARROW=">>" NIGHTHAWK_DEBOUNCE_MS=99 NIGHTHAWK_DEBUG=1 NIGHTHAWK_TAB_ACCEPT=0
 reload
-check "cfg env arrow"    ">>" "$_nh_hint_arrow"
-check "cfg env debounce" "99" "$_nh_debounce_ms"
+check "cfg env arrow"      ">>" "$_nh_hint_arrow"
+check "cfg env debounce"   "99" "$_nh_debounce_ms"
+check "cfg env tab_accept" "0"  "$_nh_tab_accept"
 
 # 4. Clamp: non-digit env resets to default; leading-zero is base-10 (not octal).
 export NIGHTHAWK_DEBOUNCE_MS=foo
@@ -255,9 +485,9 @@ check "cfg clamp non-digit -> 200" "200" "$_nh_debounce_ms"
 export NIGHTHAWK_DEBOUNCE_MS=0200
 reload
 check "cfg clamp leading-zero base10" "200" "$_nh_debounce_ms"
-unset NIGHTHAWK_HINT_ARROW NIGHTHAWK_DEBOUNCE_MS NIGHTHAWK_DEBUG
+unset NIGHTHAWK_HINT_ARROW NIGHTHAWK_DEBOUNCE_MS NIGHTHAWK_DEBUG NIGHTHAWK_TAB_ACCEPT
 
 # --- summary ---
-rm -rf "$_nh_tmpcfg"
+rm -rf "$_nh_tmpcfg" "$_nh_test_rundir"
 printf 'helpers.test.bash: %d passed, %d failed\n' "$_nh_pass" "$_nh_fail"
 (( _nh_fail == 0 ))

--- a/shells/tests/helpers.test.bash
+++ b/shells/tests/helpers.test.bash
@@ -8,9 +8,11 @@
 # is stubbed to a no-op so sourcing has no side effects. (Session 1 makes no bind calls,
 # but the stub future-proofs the harness for Session 2.)
 #
-# Requires the same tools the plugin does (bash, socat, jq on PATH); if they're missing the
-# plugin's dep-check returns early and the helpers stay undefined — caught below as a loud
-# failure, exactly like offsets.test.zsh.
+# Requires the same tools the plugin does (bash, socat, jq on PATH) AND a UTF-8 locale — run on
+# Linux/WSL, not a bare Windows shell. The 10 pure helpers are all defined ABOVE the plugin's
+# dep-check, so the structural check below passes even on a depless box; what actually fails
+# there are the jq-backed parse/pipeline assertions (and the offset rows need UTF-8). The
+# structural check guards against a rename of those helpers, not against missing deps.
 #
 # Run:  bash shells/tests/helpers.test.bash
 
@@ -137,6 +139,13 @@ check "esc quote"      'say \"hi\"' "$(_nh_json_escape 'say "hi"')"
 check "esc tab"        'x\ty'      "$(_nh_json_escape $'x\ty')"
 check "esc newline"    'x\ny'      "$(_nh_json_escape $'x\ny')"
 check "esc C0 0x01"    'a\u0001b'  "$(_nh_json_escape $'a\x01b')"
+# 0x1b (ESC) is unnamed, so it is exercised ONLY by the C0 escape loop, not the named escapes
+# above — guards against a future edit dropping ESC (the most render-dangerous byte). The
+# expected is built via printf because the source can't portably carry a lone backslash-u:
+# printf consumes the DOUBLED backslash atomically (yields one backslash) and does NOT
+# reinterpret the trailing u001b, so _esc_expect holds the literal that json_escape emits.
+printf -v _esc_expect 'a\\u001bb'
+check "esc C0 0x1b ESC" "$_esc_expect" "$(_nh_json_escape $'a\x1bb')"
 check "esc plain passthrough" 'git 中' "$(_nh_json_escape 'git 中')"
 check "build request" '{"input":"git st","cursor":6,"cwd":"/home/u","shell":"bash"}' \
     "$(_nh_build_request 'git st' 6 '/home/u')"
@@ -144,10 +153,12 @@ check "build request escapes quote" '{"input":"echo \"hi\"","cursor":9,"cwd":"/w
     "$(_nh_build_request 'echo "hi"' 9 '/w')"
 
 # ======================================================================================
-# Response parse (eval-able assignments; locals defaulted before eval)
+# Response parse (eval-able assignments; _nh_parse_response self-defaults all four fields)
 # ======================================================================================
 parse_into() {  # parse_into <json>  -> sets text/replace_start/replace_end/diff_ops_present
-    text='' replace_start='' replace_end='' diff_ops_present=0
+    # No manual defaulting here: _nh_parse_response is self-defaulting, so a bare eval can't
+    # leave stale values from a prior parse. (Exercises that contract directly — see the
+    # "not stale" case below, which seeds a sentinel first.)
     eval "$(_nh_parse_response "$1")"
 }
 parse_into '{"suggestions":[{"text":"git status","replace_start":0,"replace_end":3}]}'
@@ -159,8 +170,13 @@ parse_into '{"suggestions":[{"text":"grep","replace_start":0,"replace_end":2,"di
 check "parse diff present"  "1"          "$diff_ops_present"
 parse_into '{"suggestions":[]}'
 check "parse empty -> no text" "" "$text"
+# Seed a sentinel, then parse garbage: jq fails (no output), so ONLY the self-defaulting in
+# _nh_parse_response can clear it. Proves the reset survives a parse_into with no manual reset.
+text="STALE" replace_start="9" replace_end="9" diff_ops_present=1
 parse_into 'not json at all'
 check "parse malformed -> no text (not stale)" "" "$text"
+check "parse malformed -> rstart cleared"      "" "$replace_start"
+check "parse malformed -> diff flag cleared"   "0" "$diff_ops_present"
 
 # ======================================================================================
 # Decision logic + full pipeline (prefix-vs-hint)
@@ -190,6 +206,11 @@ check "pipeline rejects ctrl-char suggestion" "" \
 # Malformed range (null) -> no output.
 check "pipeline rejects null range" "" \
     "$(_nh_compute_suggestion 'git' '{"suggestions":[{"text":"git status"}]}')"
+# Zero-padded offset ("09") from a misbehaving daemon: base-10 normalization must parse it as
+# 9 (not trip octal in the converters). Before the 10# guard this errored to stderr and the
+# suggestion was dropped (empty); now it resolves to the correct ghost suffix.
+check "pipeline base-10 normalizes 09" $'ghost\ting' \
+    "$(_nh_compute_suggestion 'echo test' '{"suggestions":[{"text":"echo testing","replace_start":"00","replace_end":"09"}]}' 2>/dev/null)"
 
 # ======================================================================================
 # Config: precedence (default < file < env) + debounce clamp. Re-sources the plugin under

--- a/shells/tests/helpers.test.bash
+++ b/shells/tests/helpers.test.bash
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# Unit tests for the pure helpers in shells/nighthawk.bash.
+#
+# This is the bash analogue of shells/tests/offsets.test.zsh, extended to cover the
+# config/clamp, control-char, JSON-escape, parse, and prefix-vs-hint logic that the bash
+# port factors into pure functions. It is hermetic: config is isolated to a temp
+# XDG_CONFIG_HOME, NIGHTHAWK_* env overrides are unset, and the interactive `bind` builtin
+# is stubbed to a no-op so sourcing has no side effects. (Session 1 makes no bind calls,
+# but the stub future-proofs the harness for Session 2.)
+#
+# Requires the same tools the plugin does (bash, socat, jq on PATH); if they're missing the
+# plugin's dep-check returns early and the helpers stay undefined — caught below as a loud
+# failure, exactly like offsets.test.zsh.
+#
+# Run:  bash shells/tests/helpers.test.bash
+
+# --- Hermetic source ---
+bind() { :; }                                  # shadow the readline builtin (inert)
+_nh_tmpcfg=$(mktemp -d)
+export XDG_CONFIG_HOME="$_nh_tmpcfg"
+unset NIGHTHAWK_HINT_ARROW NIGHTHAWK_DEBOUNCE_MS NIGHTHAWK_DEBUG NIGHTHAWK_SOCKET
+
+_nh_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_nh_plugin="$_nh_dir/../nighthawk.bash"
+if [[ ! -r "$_nh_plugin" ]]; then
+    echo "helpers.test.bash: cannot read $_nh_plugin" >&2
+    rm -rf "$_nh_tmpcfg"
+    exit 2
+fi
+# `source` (not execute) so the plugin's `return 1` dep-check can't exit this process.
+source "$_nh_plugin"
+
+# Structural check: the helpers must exist after sourcing (guards a rename / missing deps).
+for fn in _nh_load_config _nh_log _nh_has_ctrl_char _nh_byte_to_char _nh_char_to_byte \
+          _nh_json_escape _nh_build_request _nh_parse_response _nh_decide_render \
+          _nh_compute_suggestion; do
+    if ! declare -F "$fn" >/dev/null; then
+        echo "helpers.test.bash: FAIL — $fn not defined after sourcing plugin (renamed? deps missing?)" >&2
+        rm -rf "$_nh_tmpcfg"
+        exit 2
+    fi
+done
+
+# --- Assertion harness ---
+_nh_pass=0
+_nh_fail=0
+check() {  # check <desc> <expected> <actual>
+    if [[ "$2" == "$3" ]]; then
+        (( _nh_pass++ ))
+    else
+        (( _nh_fail++ ))
+        printf "FAIL: %s — expected '%s' got '%s'\n" "$1" "$2" "$3"
+    fi
+}
+
+# ======================================================================================
+# Offset converters — mirrors offsets.test.zsh. Test data built from RAW UTF-8 BYTES (not
+# $'\U...', which is non-portable in bash) so it survives any file-encoding round-trip.
+#   a = U+0061 (1B)  é = U+00E9 (2B)  中 = U+4E2D (3B)  😀 = U+1F600 (4B)  é = U+00E9 (2B)
+#   => byte boundaries 0,1,3,6,10,12 ; 5 char units.
+# ======================================================================================
+S=$'\x61\xc3\xa9\xe4\xb8\xad\xf0\x9f\x98\x80\xc3\xa9'
+
+# --- ASCII (byte == char identity) ---
+A="git checkout"
+check "ascii b2c 0"        0  "$(_nh_byte_to_char "$A" 0)"
+check "ascii b2c 4"        4  "$(_nh_byte_to_char "$A" 4)"
+check "ascii b2c 12 (EOL)" 12 "$(_nh_byte_to_char "$A" 12)"
+check "ascii c2b 4"        4  "$(_nh_char_to_byte "$A" 4)"
+check "ascii c2b 12 (EOL)" 12 "$(_nh_char_to_byte "$A" 12)"
+
+# --- byte_to_char on code-point boundaries (2/3-byte sequences) ---
+check "b2c 0"            0 "$(_nh_byte_to_char "$S" 0)"
+check "b2c 1 (after 1B)" 1 "$(_nh_byte_to_char "$S" 1)"
+check "b2c 3 (after 2B)" 2 "$(_nh_byte_to_char "$S" 3)"
+check "b2c 6 (after 3B)" 3 "$(_nh_byte_to_char "$S" 6)"
+check "b2c 12 (EOL)"     5 "$(_nh_byte_to_char "$S" 12)"
+
+# --- mid-sequence rejections (fail-closed -> -1) ---
+check "b2c 2 (mid 2-byte)" -1 "$(_nh_byte_to_char "$S" 2)"
+check "b2c 4 (mid 3-byte)" -1 "$(_nh_byte_to_char "$S" 4)"
+check "b2c 5 (mid 3-byte)" -1 "$(_nh_byte_to_char "$S" 5)"
+
+# --- bounds & degenerate inputs ---
+check "b2c -1 (negative)" -1 "$(_nh_byte_to_char "$S" -1)"
+check "b2c 13 (past end)" -1 "$(_nh_byte_to_char "$S" 13)"
+check "b2c empty, off 0"   0 "$(_nh_byte_to_char "" 0)"
+check "b2c empty, off 1"  -1 "$(_nh_byte_to_char "" 1)"
+
+# --- char_to_byte inverse on boundaries ---
+check "c2b 0"  0  "$(_nh_char_to_byte "$S" 0)"
+check "c2b 1"  1  "$(_nh_char_to_byte "$S" 1)"
+check "c2b 2"  3  "$(_nh_char_to_byte "$S" 2)"
+check "c2b 3"  6  "$(_nh_char_to_byte "$S" 3)"
+check "c2b 5"  12 "$(_nh_char_to_byte "$S" 5)"
+check "c2b past-end clamps" 12 "$(_nh_char_to_byte "$S" 99)"
+check "c2b negative -> 0"    0 "$(_nh_char_to_byte "$S" -3)"
+
+# --- round-trip over every boundary ---
+for i in 0 1 2 3 5; do
+    b=$(_nh_char_to_byte "$S" $i)
+    check "roundtrip char $i (byte $b)" $i "$(_nh_byte_to_char "$S" $b)"
+done
+
+# --- 4-byte (astral) coverage — probe-gated. The substring-length walk needs the libc to
+# decode a 4-byte char as one unit under the UTF-8 locale; some glibc builds miscount it as
+# 2. Where that happens the converters still fail CLOSED at runtime (wrong offset -> daemon
+# reply fails validation -> no ghost), so we skip the rows rather than fail the suite. ---
+_nh_astral=$'\xf0\x9f\x98\x80'
+if [[ ${#_nh_astral} == 1 ]]; then
+    check "b2c 10 (after 4B)"  4 "$(_nh_byte_to_char "$S" 10)"
+    check "b2c 7 (mid 4-byte)" -1 "$(_nh_byte_to_char "$S" 7)"
+    check "b2c 8 (mid 4-byte)" -1 "$(_nh_byte_to_char "$S" 8)"
+    check "b2c 9 (mid 4-byte)" -1 "$(_nh_byte_to_char "$S" 9)"
+    check "c2b 4" 10 "$(_nh_char_to_byte "$S" 4)"
+    b=$(_nh_char_to_byte "$S" 4)
+    check "roundtrip char 4 (byte $b)" 4 "$(_nh_byte_to_char "$S" $b)"
+else
+    echo "NOTE: astral char miscounts as ${#_nh_astral} on this libc — 4-byte rows skipped (runtime fails closed)"
+fi
+
+# ======================================================================================
+# Control-char guard (fail-closed rejection)
+# ======================================================================================
+_nh_has_ctrl_char "git status" ; check "ctrl: clean cmd accepted"  1 "$?"
+_nh_has_ctrl_char $'ls\nrm'    ; check "ctrl: newline rejected"    0 "$?"
+_nh_has_ctrl_char $'a\x1bb'    ; check "ctrl: ESC rejected"        0 "$?"
+_nh_has_ctrl_char $'a\x7f'     ; check "ctrl: DEL rejected"        0 "$?"
+_nh_has_ctrl_char $'a\tb'      ; check "ctrl: TAB rejected"        0 "$?"
+_nh_has_ctrl_char "echo 中"    ; check "ctrl: multibyte accepted"  1 "$?"
+
+# ======================================================================================
+# JSON escaping + request build
+# ======================================================================================
+check "esc backslash" 'a\\b'      "$(_nh_json_escape 'a\b')"
+check "esc quote"      'say \"hi\"' "$(_nh_json_escape 'say "hi"')"
+check "esc tab"        'x\ty'      "$(_nh_json_escape $'x\ty')"
+check "esc newline"    'x\ny'      "$(_nh_json_escape $'x\ny')"
+check "esc C0 0x01"    'a\u0001b'  "$(_nh_json_escape $'a\x01b')"
+check "esc plain passthrough" 'git 中' "$(_nh_json_escape 'git 中')"
+check "build request" '{"input":"git st","cursor":6,"cwd":"/home/u","shell":"bash"}' \
+    "$(_nh_build_request 'git st' 6 '/home/u')"
+check "build request escapes quote" '{"input":"echo \"hi\"","cursor":9,"cwd":"/w","shell":"bash"}' \
+    "$(_nh_build_request 'echo "hi"' 9 '/w')"
+
+# ======================================================================================
+# Response parse (eval-able assignments; locals defaulted before eval)
+# ======================================================================================
+parse_into() {  # parse_into <json>  -> sets text/replace_start/replace_end/diff_ops_present
+    text='' replace_start='' replace_end='' diff_ops_present=0
+    eval "$(_nh_parse_response "$1")"
+}
+parse_into '{"suggestions":[{"text":"git status","replace_start":0,"replace_end":3}]}'
+check "parse text"          "git status" "$text"
+check "parse rstart"        "0"          "$replace_start"
+check "parse rend"          "3"          "$replace_end"
+check "parse no diff"       "0"          "$diff_ops_present"
+parse_into '{"suggestions":[{"text":"grep","replace_start":0,"replace_end":2,"diff_ops":[{"op":"keep","ch":"g"}]}]}'
+check "parse diff present"  "1"          "$diff_ops_present"
+parse_into '{"suggestions":[]}'
+check "parse empty -> no text" "" "$text"
+parse_into 'not json at all'
+check "parse malformed -> no text (not stale)" "" "$text"
+
+# ======================================================================================
+# Decision logic + full pipeline (prefix-vs-hint)
+# ======================================================================================
+# True prefix: buffer "git", suggestion "git status" replacing [0,3) -> ghost suffix.
+check "decide ghost (prefix)" $'ghost\t status' \
+    "$(_nh_decide_render 'git' 'git status' 0 0)"
+# Divergent typed text -> hint with arrow.
+check "decide hint (divergent)" $'hint\t -> git status' \
+    "$(_nh_decide_render 'gti' 'git status' 0 0)"
+# diff present -> always hint.
+check "decide hint (diff)" $'hint\t -> git status' \
+    "$(_nh_decide_render 'git' 'git status' 0 1)"
+# Self-guard: negative rstart (failed conversion) -> empty, never a bad subscript.
+check "decide guards rstart=-1" "" "$(_nh_decide_render 'git' 'git status' -1 0)"
+# Empty text -> empty.
+check "decide empty text" "" "$(_nh_decide_render 'git' '' 0 0)"
+
+# End-to-end pipeline through parse + reject + convert + validate + decide:
+check "pipeline ghost" $'ghost\t status' \
+    "$(_nh_compute_suggestion 'git' '{"suggestions":[{"text":"git status","replace_start":0,"replace_end":3}]}')"
+check "pipeline hint (divergent)" $'hint\t -> git status' \
+    "$(_nh_compute_suggestion 'gti' '{"suggestions":[{"text":"git status","replace_start":0,"replace_end":3}]}')"
+# Control char in suggestion -> rejected (no output).
+check "pipeline rejects ctrl-char suggestion" "" \
+    "$(_nh_compute_suggestion 'rm ' '{"suggestions":[{"text":"rm -rf /\n","replace_start":0,"replace_end":3}]}')"
+# Malformed range (null) -> no output.
+check "pipeline rejects null range" "" \
+    "$(_nh_compute_suggestion 'git' '{"suggestions":[{"text":"git status"}]}')"
+
+# ======================================================================================
+# Config: precedence (default < file < env) + debounce clamp. Re-sources the plugin under
+# different config/env to exercise the source-time load + override + clamp code.
+# ======================================================================================
+reload() { source "$_nh_plugin"; }   # re-runs config load + env override + clamp
+
+# 1. Defaults (empty temp config dir, env unset).
+unset NIGHTHAWK_HINT_ARROW NIGHTHAWK_DEBOUNCE_MS NIGHTHAWK_DEBUG
+rm -f "$_nh_tmpcfg/nighthawk/config.toml"
+reload
+check "cfg default arrow"    "->" "$_nh_hint_arrow"
+check "cfg default debounce" "200" "$_nh_debounce_ms"
+check "cfg default debug"    "0"  "$_nh_debug"
+
+# 2. File overrides default.
+mkdir -p "$_nh_tmpcfg/nighthawk"
+cat > "$_nh_tmpcfg/nighthawk/config.toml" <<'TOML'
+# comment
+[other]
+hint_arrow = "XX"
+[plugin]
+hint_arrow = "=>"
+debounce_ms = 350
+debug = true
+TOML
+reload
+check "cfg file arrow"    "=>"  "$_nh_hint_arrow"
+check "cfg file debounce" "350" "$_nh_debounce_ms"
+check "cfg file debug"    "1"   "$_nh_debug"
+
+# 3. Env overrides file.
+export NIGHTHAWK_HINT_ARROW=">>" NIGHTHAWK_DEBOUNCE_MS=99 NIGHTHAWK_DEBUG=1
+reload
+check "cfg env arrow"    ">>" "$_nh_hint_arrow"
+check "cfg env debounce" "99" "$_nh_debounce_ms"
+
+# 4. Clamp: non-digit env resets to default; leading-zero is base-10 (not octal).
+export NIGHTHAWK_DEBOUNCE_MS=foo
+reload
+check "cfg clamp non-digit -> 200" "200" "$_nh_debounce_ms"
+export NIGHTHAWK_DEBOUNCE_MS=0200
+reload
+check "cfg clamp leading-zero base10" "200" "$_nh_debounce_ms"
+unset NIGHTHAWK_HINT_ARROW NIGHTHAWK_DEBOUNCE_MS NIGHTHAWK_DEBUG
+
+# --- summary ---
+rm -rf "$_nh_tmpcfg"
+printf 'helpers.test.bash: %d passed, %d failed\n' "$_nh_pass" "$_nh_fail"
+(( _nh_fail == 0 ))


### PR DESCRIPTION
Adds the bash shell plugin — inline ghost-text autocomplete over the same daemon IPC the zsh/PowerShell plugins use. Brings bash from "Planned" to "Beta".

## What's here
- **Pure helper layer + unit harness** (`shells/tests/helpers.test.bash`): config/TOML load, control-char guard, UTF-8 byte↔char offset conversion, JSON request build, response parse, prefix-vs-hint decision. 141 assertions, hermetic (stubs `bind`/`/dev/tty`, scaffolds a temp run dir).
- **Async direct-paint live layer**: bash has no async callback (no `zle -F`), so a background worker paints the ghost straight to `/dev/tty` and round-trips the accept payload through a `stash` file. A monotonic generation counter is the cross-process staleness token; accept revalidates against the live buffer (control-char re-guard, EOL + byte-range re-check) so a stale ghost can never be accepted. This is what kills the flicker the synchronous approach had.
- **Opt-in Tab accept** (`tab_accept` / `NIGHTHAWK_TAB_ACCEPT`, default off): unlike zsh/PowerShell, bash's `bind -x` can't fall back to native completion, so enabling Tab-accept disables native Tab — documented as a tradeoff. Right arrow + Ctrl-F are always accept keys.

## Behavior
- Accept: **→** / **Ctrl-F** (Tab opt-in). Cursor motions (Left/Home/End) clear+invalidate the ghost; Esc dismisses; Enter clears then submits.
- Multibyte-safe throughout (char-domain edits, byte-domain splice under `LC_ALL=C`).
- Per-session run dir via `mktemp` (atomic 0700); EXIT-trap chaining preserves any pre-existing trap; dead-PID GC backstops crash/HUP cleanup.

## Testing
- Bash unit suite: **141 passed, 0 failed** (WSL, UTF-8). Note: not yet wired into CI (`ci.yml` is cargo-only) — follow-up.
- Manual-tested in a real WSL terminal: async ghost on idle (no flicker), accept keys, motions clearing cleanly, multibyte backspace, Tab opt-in both modes, Enter submit.
- Two AI code-review rounds before merge.

## Docs
- README Quickstart gains a bash note (accept keys + Tab tradeoff); support table bash → Beta.

No Rust touched — this is shell + docs only.