### PR TITLE
feat: interactive nh setup wizard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,12 +183,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -228,6 +252,12 @@ name = "doctest-file"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -767,6 +797,7 @@ version = "0.4.0"
 dependencies = [
  "async-trait",
  "clap",
+ "dialoguer",
  "dirs",
  "flate2",
  "interprocess",
@@ -777,7 +808,7 @@ dependencies = [
  "serde_json",
  "tar",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
  "tracing",
@@ -903,7 +934,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -924,7 +955,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1026,7 +1057,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1250,6 +1281,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,11 +1405,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1618,6 +1675,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,6 +1890,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 interprocess = { version = "2", features = ["tokio"] }
 clap = { version = "4", features = ["derive"] }
+dialoguer = { version = "0.11", default-features = false }
 dirs = "6"
 toml = "0.8"
 thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -50,8 +50,14 @@ cargo install nighthawk --features cloud-llm    # Tier 3: BYOK OpenAI / Anthropi
 ## Quickstart
 
 ```sh
-nh setup zsh     # installs the plugin + specs, adds a source line to ~/.zshrc (idempotent)
+nh setup         # interactive wizard: auto-detects your shell, then installs everything
 exec zsh         # reload your shell
+```
+
+Already know your shell? Skip the prompts:
+
+```sh
+nh setup zsh     # installs the plugin + specs, adds a source line to ~/.zshrc (idempotent)
 ```
 
 Start typing a command — gray ghost text shows the completion. **Tab** (or **→** at end of line) accepts, **Esc** dismisses. The daemon auto-starts on first use; manage it with `nh start` / `nh stop` / `nh status`.

--- a/shells/nighthawk.fish
+++ b/shells/nighthawk.fish
@@ -853,6 +853,20 @@ end
 # ======================================================================================
 status is-interactive; or return 0
 
+# --- fish version guard (interactive only) ---
+# The H4 key bindings below use fish 4.0+ key NAMES (right, ctrl-f, enter, escape, tab, space, …).
+# On fish 3.x those are not recognized as keys — they parse as LITERAL character sequences, turning
+# common letters (e, r, t, s, c, h, l, b, d) into chord prefixes that swallow normal typing, so the
+# shell appears to freeze on input. Bail BEFORE H1/H3/H4 so an old fish is never wedged and its
+# native autosuggestion stays intact (we have not suppressed it yet). Placed here, after the
+# interactive gate, so the non-interactive unit harness never trips it. `$version` is the running
+# fish's version (e.g. "4.2.1"); `-f1` takes the major field — non-numeric/empty also bails.
+set -l _nh_fish_major (string split -f1 . -- $version)
+if not string match -rq '^[0-9]+$' -- "$_nh_fish_major"; or test "$_nh_fish_major" -lt 4
+    echo "nighthawk: fish 4.0+ required (found $version); plugin disabled." >&2
+    return 0
+end
+
 # --- H1: suppress fish's native autosuggestion (coexist-vs-suppress — issue #87's core question) ---
 # fish's autosuggestion is native C++ that paints its own gray ghost in EXACTLY the cells the H2
 # renderer will use, and fish exposes NO public hook to read or inject into it: the only accessor,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -23,10 +23,11 @@ enum Commands {
     /// Check if the daemon is running
     Status,
 
-    /// Install shell plugin for the given shell
+    /// Install shell plugin. With no argument, launches an interactive wizard
+    /// that auto-detects your shell; pass a shell name to skip the prompts.
     Setup {
-        /// Shell to set up (zsh, bash, fish, powershell)
-        shell: String,
+        /// Shell to set up (zsh, bash, fish, powershell, pwsh). Omit for the wizard.
+        shell: Option<String>,
     },
 
     /// Test completions from the command line
@@ -43,7 +44,10 @@ pub fn run() {
         Commands::Start => daemon_ctl::start(),
         Commands::Stop => daemon_ctl::stop(),
         Commands::Status => daemon_ctl::status(),
-        Commands::Setup { shell } => setup::setup_shell(&shell),
+        Commands::Setup { shell } => match shell {
+            Some(s) => setup::setup_shell(&s),
+            None => setup::setup_wizard(),
+        },
         Commands::Complete { input } => daemon_ctl::complete(&input),
     };
 

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -1,5 +1,34 @@
 use super::paths;
+use crate::proto::{DetectionSource, Shell};
+use dialoguer::{Confirm, Select};
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
+
+/// Every shell the setup flow can install, in menu order.
+/// `(menu label, setup id)` — the id is exactly what `setup_shell` / `shell_info` accept.
+/// Single source of truth: the wizard menu and the `shell_info` error both derive from this.
+const SETUP_TARGETS: &[(&str, &str)] = &[
+    ("zsh", "zsh"),
+    ("bash", "bash"),
+    ("fish", "fish"),
+    ("Windows PowerShell 5.1", "powershell"),
+    ("PowerShell 7+ (pwsh)", "pwsh"),
+];
+
+/// Supported setup ids joined by `sep`, for usage/error messages
+/// (e.g. `"|"` for `<a|b|c>` usage, `", "` for prose).
+fn supported_shells(sep: &str) -> String {
+    SETUP_TARGETS
+        .iter()
+        .map(|(_, id)| *id)
+        .collect::<Vec<_>>()
+        .join(sep)
+}
+
+/// Index of a setup id within `SETUP_TARGETS` (its menu position), if present.
+fn target_index(id: &str) -> Option<usize> {
+    SETUP_TARGETS.iter().position(|(_, t)| *t == id)
+}
 
 /// Map shell name to plugin filename and rc file path.
 fn shell_info(shell: &str) -> Result<(&str, PathBuf), String> {
@@ -34,7 +63,8 @@ fn shell_info(shell: &str) -> Result<(&str, PathBuf), String> {
             ))
         }
         _ => Err(format!(
-            "Unknown shell: {shell}\nSupported: zsh, bash, fish, powershell"
+            "Unknown shell: {shell}\nSupported: {}",
+            supported_shells(", ")
         )),
     }
 }
@@ -269,26 +299,32 @@ pub fn setup_shell(shell: &str) -> Result<(), Box<dyn std::error::Error>> {
 
     // 4. Build rc file additions: source line + PATH line
     if shell == "fish" {
-        // Fish uses conf.d — copying the file IS the plugin setup
-        // But we still need PATH for the install dir
-        if let Some(ref bin_dir) = installed_bin_dir {
-            let fish_path_line = path_line("fish", bin_dir);
-            let fish_conf_dir = dirs::config_dir()
-                .unwrap_or_else(|| {
-                    dirs::home_dir()
-                        .unwrap_or_else(|| PathBuf::from("."))
-                        .join(".config")
-                })
-                .join("fish")
-                .join("conf.d");
-            let path_conf = fish_conf_dir.join("nighthawk_path.fish");
-            if !path_conf.exists() {
-                std::fs::create_dir_all(&fish_conf_dir)?;
-                std::fs::write(&path_conf, fish_path_line)?;
-                println!("Added PATH config to {}", path_conf.display());
+        // Fish auto-sources every *.fish in ~/.config/fish/conf.d, so the plugin
+        // must live THERE — not just in config_dir like the step-1 copy. `rc_path`
+        // (from shell_info) already points at conf.d/nighthawk.fish; write the
+        // plugin to it so fish actually loads it on startup.
+        if let Some(conf_dir) = rc_path.parent() {
+            std::fs::create_dir_all(conf_dir)?;
+
+            std::fs::write(&rc_path, content.replace("\r\n", "\n"))?;
+            println!("Installed fish plugin to {}", rc_path.display());
+
+            // Drop a PATH entry for the install dir alongside it.
+            if let Some(ref bin_dir) = installed_bin_dir {
+                let path_conf = conf_dir.join("nighthawk_path.fish");
+                if !path_conf.exists() {
+                    std::fs::write(&path_conf, path_line("fish", bin_dir))?;
+                    println!("Added PATH config to {}", path_conf.display());
+                }
             }
         }
-        println!("Fish plugin installed to {}", rc_path.display());
+
+        // Start the daemon so it's ready when the user opens a new shell.
+        if let Err(e) = super::daemon_ctl::start() {
+            eprintln!("Warning: could not start daemon: {e}");
+        }
+
+        println!("\nRestart your shell to activate nighthawk.");
         return Ok(());
     }
 
@@ -358,6 +394,111 @@ pub fn setup_shell(shell: &str) -> Result<(), Box<dyn std::error::Error>> {
     println!("\nRestart your shell to activate nighthawk.");
 
     Ok(())
+}
+
+/// Map a detected shell to its setup id, or `None` when the wizard must ask.
+///
+/// `PowerShell` → `None`: the `Shell` enum collapses Windows PowerShell 5.1 and
+/// PowerShell 7 into one variant, but they install to different profiles, so the
+/// user must disambiguate. `Nushell` → `None`: not a supported setup target.
+fn detected_target(shell: Shell) -> Option<&'static str> {
+    match shell {
+        Shell::PowerShell | Shell::Nushell => None,
+        other => Some(other.as_str()),
+    }
+}
+
+/// Interactive `nh setup` (invoked with no shell argument).
+///
+/// Detects the current shell, confirms with the user, and delegates the actual
+/// install to [`setup_shell`]. `nh setup <shell>` remains the non-interactive path.
+pub fn setup_wizard() -> Result<(), Box<dyn std::error::Error>> {
+    // 0. Explicit NIGHTHAWK_SHELL override — honored verbatim, no prompt.
+    //    Passed as a raw string (not via the Shell enum) so the powershell(5.1)
+    //    vs pwsh(7) distinction survives; other aliases (sh, bash-5.2) are
+    //    normalized the same way detection does.
+    if let Ok(raw) = std::env::var("NIGHTHAWK_SHELL") {
+        let t = raw.trim().to_lowercase();
+        if !t.is_empty() {
+            let id = match t.as_str() {
+                "powershell" | "pwsh" => Some(t.clone()),
+                other => other.parse::<Shell>().ok().map(|s| s.as_str().to_string()),
+            };
+            // Only honor the override verbatim if it names an installable target.
+            if let Some(id) = id.filter(|id| target_index(id).is_some()) {
+                return setup_shell(&id);
+            }
+            // Unparseable (e.g. "ksh") or unsupported (e.g. "nu" → nushell): fall
+            // through to detection + menu, matching the lenient behavior of
+            // Shell::detect_* rather than dead-ending on a misleading error.
+        }
+    }
+
+    // 1. Detect the shell and how we know it.
+    let (shell, source) = Shell::detect_default_with_source();
+    let target = detected_target(shell);
+
+    // 2. Only a *current-shell* signal is confident enough to auto-run / skip the
+    //    menu. $SHELL (login shell) and the platform default are not.
+    let confident = matches!(
+        source,
+        DetectionSource::ParentProcess | DetectionSource::VersionVar
+    );
+
+    // 3. dialoguer renders to stderr and reads keys from the tty, so require both
+    //    stdin and stderr to be terminals before prompting.
+    let interactive = std::io::stdin().is_terminal() && std::io::stderr().is_terminal();
+
+    if !interactive {
+        return match (confident, target) {
+            (true, Some(id)) => setup_shell(id),
+            _ => Err(format!(
+                "Could not confidently detect your shell in a non-interactive session.\n\
+                 Re-run with an explicit shell: nh setup <{}>\n\
+                 or set the NIGHTHAWK_SHELL environment variable.",
+                supported_shells("|")
+            )
+            .into()),
+        };
+    }
+
+    // 4. Interactive + confident: confirm the detected shell (Enter = yes).
+    if let (true, Some(id)) = (confident, target) {
+        match Confirm::new()
+            .with_prompt(format!("Detected {id}. Is this correct?"))
+            .default(true)
+            .interact_opt()?
+        {
+            Some(true) => return setup_shell(id),
+            Some(false) => {} // fall through to the menu
+            None => {
+                println!("Setup cancelled.");
+                return Ok(());
+            }
+        }
+    }
+
+    // 5. Menu. Pre-select the detected target, else a platform-appropriate default
+    //    (powershell on Windows, zsh on Unix) — never preselect zsh on Windows.
+    let fallback = if cfg!(windows) { "powershell" } else { "zsh" };
+    let default_idx = target
+        .and_then(target_index)
+        .or_else(|| target_index(fallback))
+        .unwrap_or(0);
+
+    let labels: Vec<&str> = SETUP_TARGETS.iter().map(|(label, _)| *label).collect();
+    match Select::new()
+        .with_prompt("Select your shell")
+        .items(&labels)
+        .default(default_idx)
+        .interact_opt()?
+    {
+        Some(i) => setup_shell(SETUP_TARGETS[i].1),
+        None => {
+            println!("Setup cancelled.");
+            Ok(())
+        }
+    }
 }
 
 #[cfg(test)]
@@ -486,5 +627,89 @@ mod tests {
                 "Expected Unix install path, got: {dir_str}"
             );
         }
+    }
+
+    // --- Wizard / setup-target tests (issue #37) ---
+
+    #[test]
+    fn detected_target_maps_plain_shells_to_ids() {
+        assert_eq!(detected_target(Shell::Zsh), Some("zsh"));
+        assert_eq!(detected_target(Shell::Bash), Some("bash"));
+        assert_eq!(detected_target(Shell::Fish), Some("fish"));
+    }
+
+    #[test]
+    fn detected_target_powershell_is_none() {
+        // 5.1 vs 7 is ambiguous from the enum — the wizard must ask.
+        assert_eq!(detected_target(Shell::PowerShell), None);
+    }
+
+    #[test]
+    fn detected_target_nushell_is_none() {
+        // Nushell is not a supported setup target.
+        assert_eq!(detected_target(Shell::Nushell), None);
+    }
+
+    #[test]
+    fn setup_targets_ids_are_accepted_by_shell_info() {
+        // Every id the wizard can offer must be installable.
+        for (_, id) in SETUP_TARGETS {
+            assert!(
+                shell_info(id).is_ok(),
+                "SETUP_TARGETS id {id:?} rejected by shell_info"
+            );
+        }
+    }
+
+    #[test]
+    fn detected_target_ids_are_valid_setup_targets() {
+        for shell in [Shell::Zsh, Shell::Bash, Shell::Fish] {
+            let id = detected_target(shell).unwrap();
+            assert!(
+                SETUP_TARGETS.iter().any(|(_, t)| *t == id),
+                "{id:?} not in SETUP_TARGETS"
+            );
+        }
+    }
+
+    #[test]
+    fn shell_info_error_lists_pwsh() {
+        // Regression: the supported-shells error must include pwsh (was stale).
+        let err = shell_info("definitely_not_a_shell").unwrap_err();
+        assert!(err.contains("pwsh"), "error should list pwsh: {err}");
+    }
+
+    #[test]
+    fn platform_default_menu_index_is_sensible() {
+        // The menu fallback must never preselect zsh on Windows.
+        let fallback = if cfg!(windows) { "powershell" } else { "zsh" };
+        let idx = target_index(fallback).unwrap();
+        assert_eq!(SETUP_TARGETS[idx].1, fallback);
+    }
+
+    #[test]
+    fn target_index_finds_known_and_rejects_unknown() {
+        assert_eq!(target_index("zsh"), Some(0));
+        assert_eq!(target_index("pwsh"), Some(SETUP_TARGETS.len() - 1));
+        assert_eq!(target_index("nushell"), None);
+        assert_eq!(target_index("ksh"), None);
+    }
+
+    #[test]
+    fn override_filter_rejects_nushell_so_it_falls_through() {
+        // Step-0 honors an override only when it names an installable target.
+        // "nu" normalizes to "nushell", which is NOT a target, so the wizard
+        // must fall through to the menu rather than dead-end on setup_shell.
+        let normalized = "nu".parse::<Shell>().unwrap().as_str(); // "nushell"
+        assert!(
+            target_index(normalized).is_none(),
+            "nushell must not be an installable target"
+        );
+    }
+
+    #[test]
+    fn supported_shells_joins_with_separator() {
+        assert_eq!(supported_shells("|"), "zsh|bash|fish|powershell|pwsh");
+        assert!(supported_shells(", ").contains("pwsh"));
     }
 }

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -37,6 +37,22 @@ impl std::str::FromStr for Shell {
     }
 }
 
+/// How the shell was determined by detection. Reported as a neutral fact;
+/// callers decide what counts as "confident" for their own UX.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetectionSource {
+    /// `NIGHTHAWK_SHELL` env var — an explicit user choice.
+    Override,
+    /// Parent process name (`/proc` or `ps`) — the actual running shell (Unix).
+    ParentProcess,
+    /// A shell version env var like `ZSH_VERSION` (Unix).
+    VersionVar,
+    /// `$SHELL` login shell — may differ from the current interactive shell.
+    ShellEnv,
+    /// No signal matched; fell back to the platform default (a guess).
+    PlatformDefault,
+}
+
 impl Shell {
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -70,7 +86,14 @@ impl Shell {
     /// Note: On Windows, only `NIGHTHAWK_SHELL` override works reliably.
     /// The hint will always suggest PowerShell unless overridden.
     pub fn detect_default() -> Self {
-        Self::detect_from(
+        Self::detect_default_with_source().0
+    }
+
+    /// Like [`detect_default`], but also reports *how* the shell was determined.
+    /// See [`DetectionSource`]. Use this when the caller needs to distinguish a
+    /// real detection from a platform-default guess (e.g. the setup wizard).
+    pub fn detect_default_with_source() -> (Shell, DetectionSource) {
+        Self::detect_from_with_source(
             std::env::var("NIGHTHAWK_SHELL").ok(),
             std::env::var("ZSH_VERSION").ok(),
             std::env::var("BASH_VERSION").ok(),
@@ -96,15 +119,37 @@ impl Shell {
         nu_version: Option<String>,
         shell_env: Option<String>,
     ) -> Self {
+        Self::detect_from_with_source(
+            nighthawk_shell,
+            zsh_version,
+            bash_version,
+            fish_version,
+            nu_version,
+            shell_env,
+        )
+        .0
+    }
+
+    /// Source-reporting counterpart of [`detect_from`]. Same branch order and
+    /// `cfg` gating — the single source of truth that [`detect_from`] delegates
+    /// to — but also returns which branch matched as a [`DetectionSource`].
+    pub fn detect_from_with_source(
+        nighthawk_shell: Option<String>,
+        zsh_version: Option<String>,
+        bash_version: Option<String>,
+        fish_version: Option<String>,
+        nu_version: Option<String>,
+        shell_env: Option<String>,
+    ) -> (Shell, DetectionSource) {
         // 1. Explicit override (highest priority)
         if let Some(shell) = detect_from_override(&nighthawk_shell) {
-            return shell;
+            return (shell, DetectionSource::Override);
         }
 
         // 2. Parent process name (most reliable on Linux)
         #[cfg(not(windows))]
         if let Some(shell) = detect_from_parent_process() {
-            return shell;
+            return (shell, DetectionSource::ParentProcess);
         }
 
         // 3. Shell-specific version env vars (current shell detection) — Unix only
@@ -114,7 +159,7 @@ impl Shell {
         if let Some(shell) =
             detect_from_version_vars(&zsh_version, &bash_version, &fish_version, &nu_version)
         {
-            return shell;
+            return (shell, DetectionSource::VersionVar);
         }
 
         // Suppress unused warnings on Windows where version vars aren't checked
@@ -126,7 +171,7 @@ impl Shell {
         // 4. $SHELL fallback (login shell) — Unix only
         #[cfg(not(windows))]
         if let Some(shell) = detect_from_shell_env(&shell_env) {
-            return shell;
+            return (shell, DetectionSource::ShellEnv);
         }
 
         #[cfg(windows)]
@@ -137,11 +182,11 @@ impl Shell {
         // 5. Platform default
         #[cfg(windows)]
         {
-            Shell::PowerShell
+            (Shell::PowerShell, DetectionSource::PlatformDefault)
         }
         #[cfg(not(windows))]
         {
-            Shell::Zsh
+            (Shell::Zsh, DetectionSource::PlatformDefault)
         }
     }
 }
@@ -572,6 +617,73 @@ mod tests {
         assert_eq!(shell, Shell::Zsh);
         #[cfg(windows)]
         assert_eq!(shell, Shell::PowerShell);
+    }
+
+    // --- DetectionSource reporting (issue #37) ---
+
+    #[test]
+    fn source_override_reports_override() {
+        let (shell, source) =
+            Shell::detect_from_with_source(Some("pwsh".into()), None, None, None, None, None);
+        assert_eq!(shell, Shell::PowerShell);
+        assert_eq!(source, DetectionSource::Override);
+    }
+
+    #[test]
+    fn source_no_env_is_platform_default() {
+        let (_, source) = Shell::detect_from_with_source(None, None, None, None, None, None);
+        assert_eq!(source, DetectionSource::PlatformDefault);
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn source_version_var_distinct_from_shell_env() {
+        // ZSH_VERSION (current shell) is reported as VersionVar, not ShellEnv,
+        // so the wizard can treat it as confident while $SHELL stays unconfident.
+        let (shell, source) = Shell::detect_from_with_source(
+            None,
+            Some("5.9".into()),
+            None,
+            None,
+            None,
+            Some("/bin/bash".into()),
+        );
+        assert_eq!(shell, Shell::Zsh);
+        assert_eq!(source, DetectionSource::VersionVar);
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn source_shell_env_reports_shell_env() {
+        // Parent-process detection may resolve first in some test environments;
+        // accept either the $SHELL fallback or a genuine parent-process match,
+        // but never a platform-default guess when $SHELL is present.
+        let (_, source) =
+            Shell::detect_from_with_source(None, None, None, None, None, Some("/bin/fish".into()));
+        assert!(
+            matches!(
+                source,
+                DetectionSource::ShellEnv | DetectionSource::ParentProcess
+            ),
+            "expected a real detection source, got {source:?}"
+        );
+    }
+
+    #[test]
+    fn detect_from_delegates_to_with_source() {
+        // detect_from must stay a thin wrapper over detect_from_with_source.
+        let args = (Some("bash".to_string()), None, None, None, None, None);
+        let plain = Shell::detect_from(
+            args.0.clone(),
+            args.1.clone(),
+            args.2.clone(),
+            args.3.clone(),
+            args.4.clone(),
+            args.5.clone(),
+        );
+        let (with_source, _) =
+            Shell::detect_from_with_source(args.0, args.1, args.2, args.3, args.4, args.5);
+        assert_eq!(plain, with_source);
     }
 
     // --- New version var detection tests (issue #64) ---


### PR DESCRIPTION
## Summary

`nh setup` with no argument now launches an interactive wizard that auto-detects the shell, confirms, and installs everything. `nh setup <shell>` remains the non-interactive shortcut.

## Changes

**Wizard (#37)**
- `proto`: `DetectionSource` enum + `detect_*_with_source()` report *how* the shell was determined; `detect_from` delegates so the detection chain has one source of truth.
- `cli`: `setup_wizard()` honors `NIGHTHAWK_SHELL` verbatim (preserving the `powershell`/`pwsh` 5.1-vs-7 distinction the `Shell` enum collapses), treats only `ParentProcess`/`VersionVar` as confident, prompts via `dialoguer` (`Confirm`/`Select` through `interact_opt` so Esc cancels cleanly), and falls back to a platform-appropriate menu default (never zsh on Windows).
- `SETUP_TARGETS` is the single source of truth for installable shells; `shell_info`'s error derives from it.
- `nh setup` clap arg is now `Option<String>`.

**Fish setup fixes** (found while verifying all shells auto-source)
- `setup_shell` wrote the fish plugin into `config_dir`, which fish never sources — it now installs to `~/.config/fish/conf.d/nighthawk.fish` and starts the daemon, matching the other shells.
- The fish plugin's key bindings use fish 4.0+ key names that wedge input on fish 3.x — it now fails closed with a clear message on older fish.

## Testing
- 210 unit + 7 integration tests pass; clippy clean; `cargo fmt` applied.
- Verified live in WSL: zsh + bash auto-source correctly; fish guard disables cleanly on fish 3.7.
- 3 plan-review rounds (PRX) + 2 code-review rounds (CRX).

Closes #37
